### PR TITLE
Deploy Maven site to gh-page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,21 @@ jdk:
   - oraclejdk8
   - openjdk8
 
+env:
+  global:
+    # GITHUB_TOKEN value to push changes to GitHub; Currently it is ued to update gh-pages.
+    - secure: "KqPuq9TiiqdOUfGq3k+XYObNjV8FxbgJeqSWK0pcWFFs5w5c4vcGmrfUSSSqNa/JJkKOBWQ6S3tJP7CRxx0uow5BvU4ZQAZLFt6VjzcUZFKGTl5soMTF2gQdyAAcwUnRX2gQKt0doO8Fid6xzfsn1KdTIWXmeqMrcTvC+d7EhxU="
 
+script:
+  - ./mvnw test -B
+  - ./mvnw site -B
+
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local_dir: $TRAVIS_BUILD_DIR/target/site
+    email: skypencil+spotbugs-bot@gmail.com
+    on:
+      branch: spotbugs
+      condition: "$JAVA_HOME = *'oracle'*"


### PR DESCRIPTION
Currently our manual has no page which explains usage of spotbugs-maven-plugin.
So I'm going to make it by https://github.com/spotbugs/spotbugs/pull/396, but Maven can generate enough site to tell usage so I want to link from manual site.

This PR will let us push maven site from `spotbugs` branch to GitHub pages.

Before you merge this PR, make sure that @spotbugs-bot can push changes to this repository.
I think that you need to add her to member of this repository.
