### PR TITLE
Revive integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - secure: "KqPuq9TiiqdOUfGq3k+XYObNjV8FxbgJeqSWK0pcWFFs5w5c4vcGmrfUSSSqNa/JJkKOBWQ6S3tJP7CRxx0uow5BvU4ZQAZLFt6VjzcUZFKGTl5soMTF2gQdyAAcwUnRX2gQKt0doO8Fid6xzfsn1KdTIWXmeqMrcTvC+d7EhxU="
 
 script:
-  - ./mvnw test -B
+  - ./mvnw verify -B -P run-its -DtestSrc=remote
   - ./mvnw site -B
 
 deploy:

--- a/src/it-tools/build-tools/src/main/resources/filters/lib-filter2.xml
+++ b/src/it-tools/build-tools/src/main/resources/filters/lib-filter2.xml
@@ -1,6 +1,6 @@
-<SpotBugsFilter>
+<FindBugsFilter>
   <!-- A method with a dead local store false positive . -->
   <Match>
     <Bug pattern="DMI_INVOKING_TOSTRING_ON_ARRAY"/>
   </Match>
-</SpotBugsFilter>
+</FindBugsFilter>

--- a/src/it-tools/build-tools/src/main/resources/whizbang/lib-filter.xml
+++ b/src/it-tools/build-tools/src/main/resources/whizbang/lib-filter.xml
@@ -1,6 +1,6 @@
-<SpotBugsFilter>
+<FindBugsFilter>
   <!-- A method with a dead local store false positive . -->
   <Match>
     <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
   </Match>
-</SpotBugsFilter>
+</FindBugsFilter>

--- a/src/it/MFINDBUGS-145/src/main/java/org/codehaus/mojo/findbugsmavenplugin/it/mfindbugs145/App.java
+++ b/src/it/MFINDBUGS-145/src/main/java/org/codehaus/mojo/findbugsmavenplugin/it/mfindbugs145/App.java
@@ -1,4 +1,4 @@
-package com.github.spotbugs.spotbugs-maven-plugin.it.mfindbugs145;
+package org.codehaus.mojo.findbugsmavenplugin.it.mfindbugs145;
 
 /**
  * Hello world!

--- a/src/it/MFINDBUGS-145/verify.bsh
+++ b/src/it/MFINDBUGS-145/verify.bsh
@@ -22,7 +22,7 @@ for ( String path : paths )
 
 File report = new File( basedir, "target/site/spotbugs.html" );
 String content = FileUtils.fileRead( report, "UTF-8" );
-if ( content.indexOf( "<a href=\"./xref/com/github/spotbugs/spotbugs-maven-plugin/it/mfindbugs145/App.html#L17\">" ) < 0 )
+if ( content.indexOf( "<a href=\"./xref/org/codehaus/mojo/findbugsmavenplugin/it/mfindbugs145/App.html#L17\">" ) < 0 )
 {
     throw new IOException( "XRef link not generated." );
 }

--- a/src/it/common.xml
+++ b/src/it/common.xml
@@ -31,13 +31,13 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
       <version>@spotbugsVersion@</version>
-    </dependency>   
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>@junitVersion@</version>
       <scope>test</scope>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>jboss</groupId>
       <artifactId>jboss-j2ee</artifactId>
@@ -49,11 +49,11 @@
       <artifactId>servlet-api</artifactId>
       <version>2.5.20110712</version>
       <scope>compile</scope>
-    </dependency>    
+    </dependency>
   </dependencies>
 
   <build>
-    <sourceDirectory>@project.build.directory@/it-src-findbugs/findbugsTestCases/src/java</sourceDirectory>
+    <sourceDirectory>@project.build.directory@/it-src-spotbugs/spotbugsTestCases/src/java</sourceDirectory>
     <testSourceDirectory>@basedir@/src/it-src/test/java</testSourceDirectory>
     <pluginManagement>
       <plugins>
@@ -114,4 +114,3 @@
   </build>
 
 </project>
-

--- a/src/it/exclude-modules/module1/src/main/excludeBugs.xml
+++ b/src/it/exclude-modules/module1/src/main/excludeBugs.xml
@@ -62,16 +62,16 @@ disagree as to whether this value is allowed to be null. Either the check is red
 or the previous dereference is erroneous.&lt;/p&gt;
 
     </Details></BugPattern><BugPattern category='CORRECTNESS' abbrev='NP' type='NP_NONNULL_PARAM_VIOLATION'><ShortDescription>Method call passes null to a nonnull parameter </ShortDescription><Details>
-      
+
       &lt;p&gt;
       This method passes a null value as the parameter of a method which
     must be nonnull. Either this parameter has been explicitly marked
     as @Nonnull, or analysis has determined that this parameter is
     always dereferenced.
       &lt;/p&gt;
-      
+
    </Details></BugPattern><BugPattern category='CORRECTNESS' abbrev='GC' type='GC_UNRELATED_TYPES'><ShortDescription>No relationship between generic parameter and method argument</ShortDescription><Details>
-     
+
      &lt;p&gt; This call to a generic collection method contains an argument
      with an incompatible class from that of the collection's parameter
     (i.e., the type of the argument is neither a supertype nor a subtype
@@ -95,9 +95,9 @@ or the previous dereference is erroneous.&lt;/p&gt;
     a &lt;code&gt;Foo&lt;/code&gt;, the equals method of argument (e.g., the equals method of the
     &lt;code&gt;Foo&lt;/code&gt; class) used to perform the equality checks.
     &lt;/p&gt;
-     
+
     </Details></BugPattern><BugPattern category='CORRECTNESS' abbrev='IO' type='IO_APPENDING_TO_OBJECT_OUTPUT_STREAM'><ShortDescription>Doomed attempt to append to an object output stream</ShortDescription><Details>
-      
+
       &lt;p&gt;
      This code opens a file in append mode and then wraps the result in an object output stream.
      This won't allow you to append to an existing object output stream stored in a file. If you want to be
@@ -111,7 +111,7 @@ or the previous dereference is erroneous.&lt;/p&gt;
       &lt;p&gt;
       TODO: example.
       &lt;/p&gt;
-      
+
     </Details></BugPattern><BugPattern category='CORRECTNESS' abbrev='INT' type='INT_BAD_COMPARISON_WITH_SIGNED_BYTE'><ShortDescription>Bad comparison of signed byte</ShortDescription><Details>
 
 &lt;p&gt; Signed bytes can only have a value in the range -128 to 127. Comparing

--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindbugsReportGenerator.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindbugsReportGenerator.groovy
@@ -691,7 +691,7 @@ class SpotbugsReportGenerator implements FindBugsInfo {
 
 		sink.tableRow_()
 
-		spotbugsResults.SpotBugsSummary.PackageStats.ClassStats.each() {classStats ->
+		spotbugsResults.FindBugsSummary.PackageStats.ClassStats.each() {classStats ->
 
 			def classStatsValue = classStats.'@class'.text()
 			def classStatsBugCount = classStats.'@bugs'.text()

--- a/src/main/groovy/org/codehaus/mojo/findbugs/XDocsReporter.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/XDocsReporter.groovy
@@ -187,8 +187,7 @@ class XDocsReporter {
 					log.debug("finish bugClass is ${bugClass}")
 					file(classname: bugClass) {
 						spotbugsResults.BugInstance.each() {bugInstance ->
-
-							if ( bugInstance.Class.@classname.text() == bugClass ) {
+							if ( bugInstance.Class.find{ it.@primary == "true" }.@classname.text() == bugClass ) {
 
 								def type = bugInstance.@type.text()
 								def category = bugInstance.@category.text()


### PR DESCRIPTION
This project supports integration test, then enable it in Travis build. This PR also fixes several problems in maven-spotbugs-plugin:

- 34568bf41e51afdc4058fbc6c42e1843c3dc4361: support multiple `<Class>` in the same `<BugInstance>`, to generate correct xdoc report (which made many integration test failed)
- ba4ed4af2ac261837f20db38a71e923c7757d099: revert over replacement to generate HTML report (which made MFINDBUGS-145 failed)