### PR TITLE
Attempting to get travis to build with java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - openjdk8
 

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,11 @@
         <!-- Override from apache parent -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compilerPluginVersion}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${enforcerPluginVersion}</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
     <servletApiVersion>3.1.0</servletApiVersion>
 
     <!-- Override from apache parent -->
+    <coberturaPluginVersion>2.7</coberturaPluginVersion>
     <enforcerPluginVersion>3.0.0-M1</enforcerPluginVersion>
   </properties>
 
@@ -381,6 +382,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
+          <version>${coberturaPluginVersion}</version>
           <configuration>
             <skip>true</skip>
           </configuration>
@@ -477,6 +479,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
+        <version>${coberturaPluginVersion}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -583,6 +586,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
+        <version>${coberturaPluginVersion}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
-    <mavenVersion>3.5.0</mavenVersion>
+    <mavenVersion>3.5.2</mavenVersion>
 
     <plexusBuildVersion>0.0.7</plexusBuildVersion>
     <plexusContainerVersion>1.7.1</plexusContainerVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <spotbugsTag>3.1.0</spotbugsTag>
 
     <antVersion>1.9.9</antVersion>
-    <groovyVersion>2.4.12</groovyVersion>
+    <groovyVersion>2.4.13</groovyVersion>
 
     <doxiaToolsVersion>1.4</doxiaToolsVersion>
     <doxiaVersion>1.7</doxiaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,8 @@
     <javaeeApiVersion>7.0</javaeeApiVersion>
     <servletApiVersion>3.1.0</servletApiVersion>
 
+    <!-- Override from apache parent -->
+    <enforcerPluginVersion>3.0.0-M1</enforcerPluginVersion>
   </properties>
 
   <dependencies>
@@ -382,6 +384,13 @@
           <configuration>
             <skip>true</skip>
           </configuration>
+        </plugin>
+
+        <!-- Override from apache parent -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${enforcerPluginVersion}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <gmavenPluginVersion>1.5</gmavenPluginVersion>
     <infoReportsPluginVersion>2.9</infoReportsPluginVersion>
     <invokerPluginVersion>3.0.0</invokerPluginVersion>
-    <javadocPluginVersion>2.10.4</javadocPluginVersion>
+    <javadocPluginVersion>3.0.0</javadocPluginVersion>
     <pluginPluginVersion>3.5</pluginPluginVersion>
     <scmPluginVersion>1.9.5</scmPluginVersion>
     <sitePluginVersion>3.6</sitePluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,15 @@
           <localCheckout>true</localCheckout>
         </configuration>
       </plugin>
+
+      <!--  Disable cobertura from parent -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
All of this in theory should work.  It does on my local windows 10 machine.  However, seems like travis is doing something different some way or another that is causing numerous java 9 issues to surface.

- Added oracle jdk9
- Updated groovy to latest 2.4.13
- Updated maven to 3.5.2
- Updated javadoc plugin to 3.0.0
- Updated enforcer plugin to 3.0.0-M1
- Updated compiler plugin to 3.7.0
- Force cobertura to latest 2.7