### PR TITLE
Updated the spotbugs-maven-plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ mvn -Dmaven.surefire.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspe
 
 Run gui with a specific version 
 ```
-mvn com.github.spotbugs:spotbugs-maven-plugin:3.1.0-SNAPSHOT:gui 
+mvn com.github.spotbugs:spotbugs-maven-plugin:3.1.1:gui 
 ```


### PR DESCRIPTION
Updated the spotbugs-maven-plugin version to 3.1.1 instead of a SNAPSHOT.