### PR TITLE
Next pending release seems to be 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ mvn -Dmaven.surefire.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspe
 
 Run gui with a specific version 
 ```
-mvn com.github.spotbugs:spotbugs-maven-plugin:3.1.0-SNAPSHOT:gui 
+mvn com.github.spotbugs:spotbugs-maven-plugin:3.1.1:gui 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.1.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>SpotBugs Maven Plugin</name>


### PR DESCRIPTION
As there is a confusion on releases. 

3.1.1 release is available on maven central but project source code is still not even having a tag for 3.1.1.

However, I am suggesting a pom update from 3.1.1-SNAPSHOT to 3.1.2-SNAPSHOT in order to resolve #26 .