### PR TITLE
Stabilize build on spotbugs branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 script:
   - ./mvnw verify -B -P run-its -DtestSrc=remote -Dinvoker.parallelThreads=4
-  - ./mvnw site -B
+  - ./mvnw site -B -Ddownloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
 deploy:
   - provider: pages


### PR DESCRIPTION
Introduce command line parameter then dependency check can be finished as expected.

before: https://travis-ci.org/spotbugs/spotbugs-maven-plugin/builds/361014420
after: https://travis-ci.org/spotbugs/spotbugs-maven-plugin/builds/363687083

refs: https://github.com/jeremylong/DependencyCheck/issues/1070#issuecomment-358981169