### PR TITLE
refs #40: stop using absolute path for local_dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
-    local_dir: $TRAVIS_BUILD_DIR/target/site
+    local_dir: target/site
     email: skypencil+spotbugs-bot@gmail.com
     on:
       repo: spotbugs/spotbugs-maven-plugin


### PR DESCRIPTION
This fix is same with following change:
https://github.com/spotbugs/spotbugs/commit/59118d93eca8a6c3b44834e0bac257e38abf6dae