### PR TITLE
Cleanup build items and stabalize build on maven 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <doxiaVersion>1.8</doxiaVersion>
     <doxiaSiteToolsVersion>1.8.1</doxiaSiteToolsVersion>
 
+    <mavenCoreVersion>3.1.1</mavenCoreVersion>
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
     <mavenVersion>3.5.0</mavenVersion> <!-- Version 3.5.3 introduces widespread issues reported across many plugins that upgraded, stay at 3.5.0 until fixed -->
@@ -265,6 +266,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenCoreVersion}</version>
     </dependency>
 
     <!-- doxia -->

--- a/pom.xml
+++ b/pom.xml
@@ -187,12 +187,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
       <version>${spotbugsVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- gmaven -->

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
     <mavenVersion>3.5.0</mavenVersion> <!-- Version 3.5.3 introduces widespread issues reported across many plugins that upgraded, stay at 3.5.0 until fixed -->
 
-    <plexusBuildVersion>0.0.7</plexusBuildVersion>
     <plexusContainerVersion>1.7.1</plexusContainerVersion>
     <plexusResourcesVersion>1.1.0</plexusResourcesVersion>
     <plexusUtilsVersion>3.1.0</plexusUtilsVersion>
@@ -396,11 +395,6 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>${plexusUtilsVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.plexus</groupId>
-      <artifactId>plexus-build-api</artifactId>
-      <version>${plexusBuildVersion}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,16 +196,6 @@
       <artifactId>ant</artifactId>
       <version>${antVersion}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant-antlr</artifactId>
-      <version>${antVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant-junit</artifactId>
-      <version>${antVersion}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
@@ -217,6 +207,20 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-ant</artifactId>
       <version>${groovyVersion}</version>
+      <exclusions>
+          <exclusion>
+              <groupId>org.apache.ant</groupId>
+              <artifactId>ant-junit</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>org.apache.ant</groupId>
+              <artifactId>ant-antlr</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-groovydoc</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -46,8 +46,6 @@ import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.resource.loader.FileResourceCreationException
 import org.codehaus.plexus.resource.loader.FileResourceLoader
 
-import org.sonatype.plexus.build.incremental.BuildContext
-
 /**
  * Generates a SpotBugs Report when the site plugin is run.
  * The HTML report is generated for site commands only.


### PR DESCRIPTION
We already require maven 3.1.1 but still had maven core 3.0.0.