### PR TITLE
Fix lifecycle mapping metadata

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -3,7 +3,7 @@
         <pluginExecution>
             <pluginExecutionFilter>
                 <goals>
-                    <goal>compile</goal>
+                    <goal>check</goal>
                 </goals>
             </pluginExecutionFilter>
             <action>


### PR DESCRIPTION
I've fixed `<goal>` in `META-INF/m2e/lifecycle-mapping-metadata.xml`, however this fix isn't enough to run SpotBugs from m2e. I've installed `3.1.6-SNAPSHOT` in local, and confirmed that its goal is linked with lifecycle:

![screenshot from 2018-07-02 09-31-56](https://user-images.githubusercontent.com/505751/42141443-df872a12-7ddb-11e8-89e5-61f003b986de.png)

But even when I clean the Eclipse project, it won't run SpotBugs. At least, I found nothing in in progress bar, and no report founds in `target` directory.