### PR TITLE
Add new parameter to provide SpotBugs with source paths from Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>3.5.3</maven>
+    <maven>3.1.1</maven>
   </prerequisites>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>3.1.1</maven>
+    <maven>3.5.3</maven>
   </prerequisites>
 
   <scm>
@@ -116,7 +116,7 @@
     <projectVersion>${project.version}</projectVersion>
 
     <junitVersion>5.2.0</junitVersion>
-    <spotbugsVersion>3.1.5</spotbugsVersion>
+    <spotbugsVersion>4.0.0-SNAPSHOT</spotbugsVersion>
     <spotbugsTag>3.1.5</spotbugsTag>
 
     <antVersion>1.10.4</antVersion>
@@ -203,7 +203,7 @@
       <version>${groovyVersion}</version>
       <classifier>indy</classifier>
     </dependency>
-    
+
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -155,6 +155,13 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     boolean includeTests
 
     /**
+     * Run Spotbugs with -sourcepath parameter populated with the known source roots.
+     *
+     */
+    @Parameter(defaultValue = "false", property = "spotbugs.addSourceDirs")
+    boolean addSourceDirs
+
+    /**
      * List of artifacts this plugin depends on. Used for resolving the Spotbugs coreplugin.
      *
      */
@@ -484,7 +491,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      */
     @Parameter(property = "spotbugs.skipEmptyReport", defaultValue = "false")
     boolean skipEmptyReport
-    
+
     /**
      * Set the path of the user preferences file to use.
      * Will try to read the path as a resource before treating it as a local path.
@@ -889,6 +896,17 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 args << "-excludeBugs"
                 args << resourceHelper.getResourceFile(excludeFile.trim())
             }
+        }
+
+        if (addSourceDirs) {
+            log.debug("  Adding Source directories (To process source exclusions)")
+            args << "-sourcepath"
+            String sourceRoots = "";
+            compileSourceRoots.each() { sourceRoots += it + File.pathSeparator }
+            if (includeTests) {
+                testSourceRoots.each() { sourceRoots + it + File.pathSeparator }
+            }
+            args << sourceRoots.substring(0, sourceRoots.length() -1);
         }
 
         if (maxRank) {


### PR DESCRIPTION
Initial PR for review to add support for full source paths on source filter (when available).

The only thing I'm not sure about in this PR is the prerequisite maven version that will not normally compile unless upped to 3.5.3, that will inhibit users from taking advantage of this plugin unless in the 3.5.3 version or upper.

This should be paired with spotbugs PR #700, as it basically enables the functionality there to be used by the maven plugin.