### PR TITLE
[site] Update site distro url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     </snapshotRepository>
     <site>
       <id>gh-pages</id>
-      <url>git:ssh://git@github.com/spotbugs/spotbugs-maven-plugin.git?gh-pages#</url>
+      <url>github:ssh://spotbugs.github.io/spotbugs-maven-plugin/</url>
     </site>
   </distributionManagement>
 


### PR DESCRIPTION
base parent uses a different format which causes underlying usage to try to append to base parent location which fails.  This corrects the issue so releases will properly deploy site.