### PR TITLE
Proposal to change copyright holder described in maven site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,10 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
+  <organization>
+    <name>Garvin Leclaire</name>
+    <url>https://github.com/gleclaire</url>
+  </organization>
   <developers>
     <developer>
       <id>cr</id>


### PR DESCRIPTION
Currently [our site generated by Maven](https://spotbugs.github.io/spotbugs-maven-plugin/) uses @hazendaz's name as copyright holder of this project, because [our site skin uses `<organization>` info in `pom.xml`](https://github.com/apache/maven-skins/blob/eb1c0bf6023923def8b5fdd557fa8bc789d513f8/maven-fluido-skin/src/main/resources/META-INF/maven/site-macros.vm#L397-L420) and [the parent project uses his name as organization](https://github.com/hazendaz/base-parent/blob/14977e3ef9ea05395e081a1cafba8cb0f2e5831e/pom.xml#L29-L32).

In my understanding, the copyright holder of this project is @gleclaire, then I propose to add `<organization>` into this `pom.xml` to overwrite config in parent project.

@gleclaire @hazendaz could you review this PR? Thanks in advance! :)