### PR TITLE
Add new parameter to provide SpotBugs with source paths from Maven

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -158,6 +158,13 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     boolean includeTests
 
     /**
+     * Run Spotbugs with -sourcepath parameter populated with the known source roots.
+     *
+     */
+    @Parameter(defaultValue = "false", property = "spotbugs.addSourceDirs")
+    boolean addSourceDirs
+
+    /**
      * List of artifacts this plugin depends on. Used for resolving the Spotbugs coreplugin.
      *
      */
@@ -901,6 +908,17 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 args << "-excludeBugs"
                 args << resourceHelper.getResourceFile(excludeFile.trim())
             }
+        }
+
+        if (addSourceDirs) {
+            log.debug("  Adding Source directories (To process source exclusions)")
+            args << "-sourcepath"
+            String sourceRoots = "";
+            compileSourceRoots.each() { sourceRoots += it + File.pathSeparator }
+            if (includeTests) {
+                testSourceRoots.each() { sourceRoots + it + File.pathSeparator }
+            }
+            args << sourceRoots.substring(0, sourceRoots.length() -1);
         }
 
         if (maxRank) {


### PR DESCRIPTION
In answer to #71 . @Irian81 mentioned a lack of time and resources to push on the task.

I suggest to close #71 and to conitnue working ton this PR.

The code changes are considered to support the changes on the spotbugs core functionality related to spotbugs/spotbugs#694 together with PR spotbugs/spotbugs#903.