### PR TITLE
Revert "[pom] Add exclusion for dependency-check-plugin on system scope"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -694,15 +694,6 @@
               </execution>
             </executions>
           </plugin>
-
-          <!-- Add override to get past travis issue with system provided jdk -->
-          <plugin>
-            <groupId>org.owasp</groupId>
-            <artifactId>dependency-check-maven</artifactId>
-            <configuration>
-                <skipSystemScope>true</skipSystemScope>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
This reverts commit d79903720010f4710299e8c743b2103b69d3dd5f.

And further gives a round of testing to confirm pull requests don't cause site release.