### PR TITLE
Configurable output filename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
 
-  <groupId>com.hotelsbdp</groupId>
+  <groupId>com.hotels.bdp</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
   <version>3.1.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
 
-  <groupId>com.github.spotbugs</groupId>
+  <groupId>com.hotelsbdp</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
   <version>3.1.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
@@ -102,21 +102,32 @@
   </issueManagement>
   <distributionManagement>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>hcomdata-maven-release-local</id>
+      <name>HCom Data Internal Releases</name>
+      <url>${maven.distribution.repo.release.url}</url>
     </repository>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>hcomdata-maven-snapshot-local</id>
+      <name>HCom Data Internal Snapshots</name>
+      <url>${maven.distribution.repo.snapshot.url}</url>
     </snapshotRepository>
-    <site>
-      <id>gh-pages</id>
-      <url>github:ssh://spotbugs.github.io/spotbugs-maven-plugin/</url>
-    </site>
   </distributionManagement>
 
   <properties>
     <projectVersion>${project.version}</projectVersion>
+
+    <!-- default artifact distribution repositories -->
+    <artifactory.base>artylab.expedia.biz</artifactory.base>
+    <artifactory.base.url>https://${artifactory.base}</artifactory.base.url>
+    <artifactory.maven.release.repository.id>hcomdata-maven-release-local</artifactory.maven.release.repository.id>
+    <artifactory.maven.snapshot.repository.id>hcomdata-maven-snapshot-local</artifactory.maven.snapshot.repository.id>
+    <artifactory.rpm.release.repository.id>hcomdata-rpm-release-local</artifactory.rpm.release.repository.id>
+    <artifactory.rpm.snapshot.repository.id>hcomdata-rpm-snapshot-local</artifactory.rpm.snapshot.repository.id>
+    <artifactory.docker.release.repository.id>hcomdata-docker-release-local</artifactory.docker.release.repository.id>
+    <artifactory.docker.snapshot.repository.id>hcomdata-docker-snapshot-local</artifactory.docker.snapshot.repository.id>
+    <!-- by default we release to the maven repo but these could be overridden in child projects to release elsewhere -->
+    <maven.distribution.repo.release.url>${artifactory.base.url}/${artifactory.maven.release.repository.id}</maven.distribution.repo.release.url>
+    <maven.distribution.repo.snapshot.url>${artifactory.base.url}/${artifactory.maven.snapshot.repository.id}</maven.distribution.repo.snapshot.url>
 
     <junitVersion>5.4.2</junitVersion>
     <spotbugsVersion>3.1.12</spotbugsVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.hotels.bdp</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>3.1.14-SNAPSHOT-HOTELS</version>
+  <version>3.1.14-hcom1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>SpotBugs Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.hotels.bdp</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>3.1.13-SNAPSHOT</version>
+  <version>3.1.14-SNAPSHOT-HOTELS</version>
   <packaging>maven-plugin</packaging>
 
   <name>SpotBugs Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
     <mavenVersion>3.5.0</mavenVersion> <!-- Version 3.5.3+ introduces issues for many users of spotbugs that cannot upgrade maven to latest -->
+    <maven.min-version>3.5.0</maven.min-version>
 
     <plexusContainerVersion>2.0.0</plexusContainerVersion>
     <plexusResourcesVersion>1.1.0</plexusResourcesVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <relativePath />
   </parent>
 
-  <groupId>com.hotels.bdp</groupId>
+  <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>3.1.14-hcom1-SNAPSHOT</version>
+  <version>3.1.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>SpotBugs Maven Plugin</name>
@@ -102,32 +102,21 @@
   </issueManagement>
   <distributionManagement>
     <repository>
-      <id>hcomdata-maven-release-local</id>
-      <name>HCom Data Internal Releases</name>
-      <url>${maven.distribution.repo.release.url}</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
-      <id>hcomdata-maven-snapshot-local</id>
-      <name>HCom Data Internal Snapshots</name>
-      <url>${maven.distribution.repo.snapshot.url}</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <site>
+      <id>gh-pages</id>
+      <url>github:ssh://spotbugs.github.io/spotbugs-maven-plugin/</url>
+    </site>
   </distributionManagement>
 
   <properties>
     <projectVersion>${project.version}</projectVersion>
-
-    <!-- default artifact distribution repositories -->
-    <artifactory.base>artylab.expedia.biz</artifactory.base>
-    <artifactory.base.url>https://${artifactory.base}</artifactory.base.url>
-    <artifactory.maven.release.repository.id>hcomdata-maven-release-local</artifactory.maven.release.repository.id>
-    <artifactory.maven.snapshot.repository.id>hcomdata-maven-snapshot-local</artifactory.maven.snapshot.repository.id>
-    <artifactory.rpm.release.repository.id>hcomdata-rpm-release-local</artifactory.rpm.release.repository.id>
-    <artifactory.rpm.snapshot.repository.id>hcomdata-rpm-snapshot-local</artifactory.rpm.snapshot.repository.id>
-    <artifactory.docker.release.repository.id>hcomdata-docker-release-local</artifactory.docker.release.repository.id>
-    <artifactory.docker.snapshot.repository.id>hcomdata-docker-snapshot-local</artifactory.docker.snapshot.repository.id>
-    <!-- by default we release to the maven repo but these could be overridden in child projects to release elsewhere -->
-    <maven.distribution.repo.release.url>${artifactory.base.url}/${artifactory.maven.release.repository.id}</maven.distribution.repo.release.url>
-    <maven.distribution.repo.snapshot.url>${artifactory.base.url}/${artifactory.maven.snapshot.repository.id}</maven.distribution.repo.snapshot.url>
 
     <junitVersion>5.4.2</junitVersion>
     <spotbugsVersion>3.1.12</spotbugsVersion>
@@ -145,7 +134,6 @@
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
     <mavenVersion>3.5.0</mavenVersion> <!-- Version 3.5.3+ introduces issues for many users of spotbugs that cannot upgrade maven to latest -->
-    <maven.min-version>3.5.0</maven.min-version>
 
     <plexusContainerVersion>2.0.0</plexusContainerVersion>
     <plexusResourcesVersion>1.1.0</plexusResourcesVersion>

--- a/src/it/change-xml-filename/invoker.properties
+++ b/src/it/change-xml-filename/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/change-xml-filename/pom.xml
+++ b/src/it/change-xml-filename/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (C) 2006-2017 the original author or authors.
+    Copyright (C) 2006-2019 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,12 +33,11 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.13-SNAPSHOT</version>
         <configuration>
           <spotbugsXmlOutput>true</spotbugsXmlOutput>
           <xmlOutput>true</xmlOutput>
           <relaxed>true</relaxed>
-          <xmlOutputFilename>findbugsXml.xml</xmlOutputFilename>
+          <spotbugsXmlOutputFilename>findbugsXml.xml</spotbugsXmlOutputFilename>
         </configuration>
       </plugin>
     </plugins>

--- a/src/it/change-xml-filename/pom.xml
+++ b/src/it/change-xml-filename/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2017 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>change-filename</artifactId>
+  <name>change-filename</name>
+  <packaging>jar</packaging>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.13-SNAPSHOT</version>
+        <configuration>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <relaxed>true</relaxed>
+          <xmlOutputFilename>findbugsXml.xml</xmlOutputFilename>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/change-xml-filename/verify.groovy
+++ b/src/it/change-xml-filename/verify.groovy
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-def effortLevel = 'default'
-
-
 File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
 assert spotbugsHtml.exists()
 
@@ -30,8 +27,6 @@ assert spotbugXml.exists()
 println '***************************'
 println "Checking HTML file"
 println '***************************'
-
-assert spotbugsHtml.text.contains( "<i>" + effortLevel + "</i>" )
 
 def xhtmlParser = new XmlSlurper();
 xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)

--- a/src/it/change-xml-filename/verify.groovy
+++ b/src/it/change-xml-filename/verify.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def effortLevel = 'default'
+
+
+File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
+assert spotbugsHtml.exists()
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/findbugsXml.xml')
+assert spotbugXml.exists()
+
+
+println '***************************'
+println "Checking HTML file"
+println '***************************'
+
+assert spotbugsHtml.text.contains( "<i>" + effortLevel + "</i>" )
+
+def xhtmlParser = new XmlSlurper();
+xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+xhtmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+def path = xhtmlParser.parse( spotbugsHtml )
+//*[@id="contentBox"]/div[2]/table/tbody/tr[2]/td[2]
+def spotbugsErrors = path.body.'**'.find {div -> div.@id == 'contentBox'}.div[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+
+assert xdocErrors == spotbugsXmlErrors
+
+assert spotbugsErrors == spotbugsXmlErrors
+

--- a/src/it/change-xml-filename/verify.groovy
+++ b/src/it/change-xml-filename/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 the original author or authors.
+ * Copyright (C) 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,8 @@
  * limitations under the License.
  */
 
-File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
-assert spotbugsHtml.exists()
-
-File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
-assert spotbugXdoc.exists()
-
 File spotbugXml = new File(basedir, 'target/findbugsXml.xml')
 assert spotbugXml.exists()
-
-
-println '***************************'
-println "Checking HTML file"
-println '***************************'
-
-def xhtmlParser = new XmlSlurper();
-xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
-xhtmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-def path = xhtmlParser.parse( spotbugsHtml )
-//*[@id="contentBox"]/div[2]/table/tbody/tr[2]/td[2]
-def spotbugsErrors = path.body.'**'.find {div -> div.@id == 'contentBox'}.div[1].table.tr[1].td[1].toInteger()
-println "Error Count is ${spotbugsErrors}"
 
 
 println '**********************************'
@@ -48,18 +29,5 @@ def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
 println "BugInstance size is ${spotbugsXmlErrors}"
 
 
-println '***************************'
-println "Checking xDoc file"
-println '***************************'
-
-path = new XmlSlurper().parse(spotbugXdoc)
-
-allNodes = path.depthFirst().collect{ it }
-def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
-println "BugInstance size is ${xdocErrors}"
-
-
-assert xdocErrors == spotbugsXmlErrors
-
-assert spotbugsErrors == spotbugsXmlErrors
+assert spotbugsXmlErrors > 0
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -180,6 +180,9 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 	@Component(role = ResourceManager.class)
 	ResourceManager resourceManager
 
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
+
     void execute() {
 
         def ant = new AntBuilder()
@@ -221,7 +224,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/spotbugsXml.xml"
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlOutputFilename}"
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -185,8 +185,8 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
-    String xmlReportFilename
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
 
     void execute() {
 
@@ -229,7 +229,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlReportFilename}"
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlOutputFilename}"
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -230,7 +230,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + spotbugsXmlOutputFilename.toString()
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${spotbugsXmlOutputFilename}"
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -180,6 +180,11 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 	@Component(role = ResourceManager.class)
 	ResourceManager resourceManager
 
+    /**
+     * Set the name of the output file produced
+     *
+     * @since 3.1.13
+     */
     @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
     String xmlOutputFilename
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -230,7 +230,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${spotbugsXmlOutputFilename}"
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/" + spotbugsXmlOutputFilename
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -155,6 +155,14 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
     File spotbugsXmlOutputDirectory
 
     /**
+     * Set the name of the output XML file produced
+     *
+     * @since 3.1.13
+     */
+    @Parameter(property = "spotbugs.outputXmlFilename", defaultValue = "spotbugsXml.xml")
+    String spotbugsXmlOutputFilename
+
+    /**
      * The file encoding to use when reading the source files. If the property <code>project.build.sourceEncoding</code>
      * is not set, the platform default encoding is used. <strong>Note:</strong> This parameter always overrides the
      * property <code>charset</code> from Checkstyle's <code>TreeWalker</code> module.
@@ -180,13 +188,6 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 	@Component(role = ResourceManager.class)
 	ResourceManager resourceManager
 
-    /**
-     * Set the name of the output XML file produced
-     *
-     * @since 3.1.13
-     */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
 
     void execute() {
 
@@ -229,7 +230,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlOutputFilename}"
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + spotbugsXmlOutputFilename.toString()
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -185,8 +185,8 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
+    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
+    String xmlReportFilename
 
     void execute() {
 
@@ -229,7 +229,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
                 arg(value: spotbugsArg)
             }
 
-            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlOutputFilename}"
+            def spotbugsXmlName = spotbugsXmlOutputDirectory.toString() + "/${xmlReportFilename}"
             def spotbugsXml = new File(spotbugsXmlName)
 
             if ( spotbugsXml.exists() ) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -181,7 +181,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 	ResourceManager resourceManager
 
     /**
-     * Set the name of the output file produced
+     * Set the name of the output XML file produced
      *
      * @since 3.1.13
      */

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -101,6 +101,14 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     File spotbugsXmlOutputDirectory
 
     /**
+     * Set the name of the output XML file produced
+     *
+     * @since 3.1.13
+     */
+    @Parameter(property = "spotbugs.outputXmlFilename", defaultValue = "spotbugsXml.xml")
+    String spotbugsXmlOutputFilename
+
+    /**
      * Doxia Site Renderer.
      */
     @Component(role = Renderer.class)
@@ -515,14 +523,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     @Parameter(property = "spotbugs.userPrefs")
     String userPrefs
 
-    /**
-     * Set the name of the output XML file produced
-     *
-     * @since 3.1.13
-     */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
-
     int bugCount
 
     int errorCount
@@ -563,7 +563,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         if (canGenerate && outputSpotbugsFile == null) {
-            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
+            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${spotbugsXmlOutputFilename}")
 
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -44,7 +44,7 @@ import org.apache.maven.reporting.AbstractMavenReport
 import org.apache.maven.repository.RepositorySystem
 
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver
-
+import org.codehaus.mojo.spotbugs.SpotBugsPluginsTrait
 import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.resource.loader.FileResourceCreationException
 import org.codehaus.plexus.resource.loader.FileResourceLoader
@@ -516,6 +516,9 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     @Parameter(property = "spotbugs.userPrefs")
     String userPrefs
 
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
+
     int bugCount
 
     int errorCount
@@ -556,7 +559,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         if (canGenerate && outputSpotbugsFile == null) {
-            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/spotbugsXml.xml")
+            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
 
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -516,7 +516,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     String userPrefs
 
     /**
-     * Set the name of the output file produced
+     * Set the name of the output XML file produced
      *
      * @since 3.1.13
      */

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -740,7 +740,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 }
 
                 XDocsReporter xDocsReporter = new XDocsReporter(getBundle(locale), log, threshold, effort, outputEncoding)
-                xDocsReporter.setOutputWriter(new OutputStreamWriter(new FileOutputStream(new File("${xmlOutputDirectory}/findbugs.xml")), outputEncoding))
+                xDocsReporter.setOutputWriter(new OutputStreamWriter(new FileOutputStream(new File("${xmlOutputDirectory}/spotbugs.xml")), outputEncoding))
                 xDocsReporter.setSpotbugsResults(new XmlSlurper().parse(outputSpotbugsFile))
                 xDocsReporter.setCompileSourceRoots(this.compileSourceRoots)
                 xDocsReporter.setTestSourceRoots(this.testSourceRoots)

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -44,7 +44,6 @@ import org.apache.maven.reporting.AbstractMavenReport
 import org.apache.maven.repository.RepositorySystem
 
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver
-import org.codehaus.mojo.spotbugs.SpotBugsPluginsTrait
 import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.resource.loader.FileResourceCreationException
 import org.codehaus.plexus.resource.loader.FileResourceLoader

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -520,8 +520,8 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
+    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
+    String xmlReportFilename
 
     int bugCount
 
@@ -563,7 +563,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         if (canGenerate && outputSpotbugsFile == null) {
-            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
+            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlReportFilename}")
 
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -515,6 +515,11 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     @Parameter(property = "spotbugs.userPrefs")
     String userPrefs
 
+    /**
+     * Set the name of the output file produced
+     *
+     * @since 3.1.13
+     */
     @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
     String xmlOutputFilename
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -740,7 +740,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 }
 
                 XDocsReporter xDocsReporter = new XDocsReporter(getBundle(locale), log, threshold, effort, outputEncoding)
-                xDocsReporter.setOutputWriter(new OutputStreamWriter(new FileOutputStream(new File("${xmlOutputDirectory}/spotbugs.xml")), outputEncoding))
+                xDocsReporter.setOutputWriter(new OutputStreamWriter(new FileOutputStream(new File("${xmlOutputDirectory}/findbugs.xml")), outputEncoding))
                 xDocsReporter.setSpotbugsResults(new XmlSlurper().parse(outputSpotbugsFile))
                 xDocsReporter.setCompileSourceRoots(this.compileSourceRoots)
                 xDocsReporter.setTestSourceRoots(this.testSourceRoots)

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -520,8 +520,8 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
-    String xmlReportFilename
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
 
     int bugCount
 
@@ -563,7 +563,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         if (canGenerate && outputSpotbugsFile == null) {
-            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlReportFilename}")
+            outputSpotbugsFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
 
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -472,6 +472,11 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
     @Parameter( property="spotbugs.maxAllowedViolations" , defaultValue = "0")
     int maxAllowedViolations
 
+    /**
+     * Set the name of the output file produced
+     *
+     * @since 3.1.13
+     */
     @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
     String xmlOutputFilename
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -473,7 +473,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
     int maxAllowedViolations
 
     /**
-     * Set the name of the output file produced
+     * Set the name of the output XML file produced
      *
      * @since 3.1.13
      */

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -472,6 +472,9 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
     @Parameter( property="spotbugs.maxAllowedViolations" , defaultValue = "0")
     int maxAllowedViolations
 
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
+
     void execute() {
         Locale locale = Locale.getDefault()
         List sourceFiles
@@ -494,7 +497,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
                 }
             }
 
-            File outputFile = new File("${spotbugsXmlOutputDirectory}/spotbugsXml.xml")
+            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
 
             if (outputFile.exists()) {
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -477,8 +477,8 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
-    String xmlReportFilename
+    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
+    String xmlOutputFilename
 
     void execute() {
         Locale locale = Locale.getDefault()
@@ -502,7 +502,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
                 }
             }
 
-            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlReportFilename}")
+            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
 
             if (outputFile.exists()) {
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -477,8 +477,8 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
      *
      * @since 3.1.13
      */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
+    @Parameter(property = "spotbugs.reportFileName", defaultValue = "spotbugsXml.xml")
+    String xmlReportFilename
 
     void execute() {
         Locale locale = Locale.getDefault()
@@ -502,7 +502,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
                 }
             }
 
-            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
+            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlReportFilename}")
 
             if (outputFile.exists()) {
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -99,6 +99,14 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
     File spotbugsXmlOutputDirectory
 
     /**
+     * Set the name of the output XML file produced
+     *
+     * @since 3.1.13
+     */
+    @Parameter(property = "spotbugs.outputXmlFilename", defaultValue = "spotbugsXml.xml")
+    String spotbugsXmlOutputFilename
+
+    /**
      * Doxia Site Renderer.
      */
     @Component( role = Renderer.class)
@@ -472,13 +480,6 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
     @Parameter( property="spotbugs.maxAllowedViolations" , defaultValue = "0")
     int maxAllowedViolations
 
-    /**
-     * Set the name of the output XML file produced
-     *
-     * @since 3.1.13
-     */
-    @Parameter(property = "spotbugs.outputXmlFileName", defaultValue = "spotbugsXml.xml")
-    String xmlOutputFilename
 
     void execute() {
         Locale locale = Locale.getDefault()
@@ -502,7 +503,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
                 }
             }
 
-            File outputFile = new File("${spotbugsXmlOutputDirectory}/${xmlOutputFilename}")
+            File outputFile = new File("${spotbugsXmlOutputDirectory}/${spotbugsXmlOutputFilename}")
 
             if (outputFile.exists()) {
 


### PR DESCRIPTION
Fixes #96 
This change adds an extra parameter to the configuration so you can change the file name of the spotbugsXml.xml output file