### PR TITLE
Adding the xml declaration with the effective encoding in outputSpotbugsFile

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1134,7 +1134,10 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 outputFile.createNewFile()
 
                 def writer = outputFile.newWriter(effectiveEncoding)
-                writer.write "\n"
+				
+				writer.write "<?xml version=\"1.0\" encoding=\"" + effectiveEncoding + "\"?>"
+				
+				writer.write "\n"
 
                 writer << xmlBuilder.bind { mkp.yield path }
             } else {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1135,9 +1135,9 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
                 def writer = outputFile.newWriter(effectiveEncoding)
 				
-				writer.write "<?xml version=\"1.0\" encoding=\"" + effectiveEncoding + "\"?>"
+                writer.write "<?xml version=\"1.0\" encoding=\"" + effectiveEncoding + "\"?>"
 				
-				writer.write "\n"
+                writer.write "\n"
 
                 writer << xmlBuilder.bind { mkp.yield path }
             } else {


### PR DESCRIPTION
Adding the xml declaration with the effective encoding in outputSpotbugsFile. 

It resolves a problem when the project uses the sourceEncoding diferent of UTF-8 (e.g: CP1252) which can cause error **MalformedByteSequenceException: Byte inválido 2 da sequência UTF-8 do byte 3**.