### PR TITLE
Add opens for Groovy ReflectionUtils

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -21,6 +21,7 @@ package org.codehaus.mojo.spotbugs
 
 import groovy.xml.XmlSlurper
 import groovy.xml.StreamingMarkupBuilder
+import org.codehaus.groovy.reflection.ReflectionUtils
 
 import org.apache.maven.artifact.Artifact
 import org.apache.maven.artifact.repository.ArtifactRepository
@@ -620,6 +621,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         return SpotBugsInfo.PLUGIN_NAME
     }
 
+    private void addOpensForReflectionUtils() {
+        if (!ReflectionUtils.class.getModule().isNamed()) {
+            Collections.class.getModule().addOpens(Collections.class.getPackageName(), ReflectionUtils.class.getModule());
+        }
+    }
+
     /**
      * Executes the generation of the report.
      *
@@ -701,6 +708,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         Locale locale = Locale.getDefault()
         if (!skip) {
+            addOpensForReflectionUtils()
             executeCheck(locale)
             if (canGenerateReport()) {
                 generateXDoc(locale)


### PR DESCRIPTION
Based on this [StackOverflow post](https://stackoverflow.com/questions/46454995/how-to-hide-warning-illegal-reflective-access-in-java-9-without-jvm-argument) I've programmatically added some add-opens for the Groovy ReflectionUtils class. That resolves the warnings in #132 for me on Java 11. These are still not fixed in Groovy 3.0.0-rc-3 . :-/