### PR TITLE
Tune logging to prevent illegal reflective operation warnings

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -636,15 +636,14 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         if (!skip && canGenerateReport()) {
 
-            log.debug("Locale is ${locale.getLanguage()}")
-
-            log.debug("****** SpotBugsMojo executeReport *******")
-
-            log.debug("report Output Directory is " + getReportOutputDirectory())
-            log.debug("Output Directory is " + outputDirectory)
-            log.debug("Classes Directory is " + classFilesDirectory)
-
-            log.debug("  Plugin Artifacts to be added ->" + pluginArtifacts.toString())
+            if (log.isDebugEnabled()) {
+                log.debug("Locale is ${locale.getLanguage()}")
+                log.debug("****** SpotBugsMojo executeReport *******")
+                log.debug("report Output Directory is " + getReportOutputDirectory())
+                log.debug("Output Directory is " + outputDirectory)
+                log.debug("Classes Directory is " + classFilesDirectory)
+                log.debug("  Plugin Artifacts to be added ->" + pluginArtifacts.toString())
+            }
 
             generateXDoc(locale)
 
@@ -1020,15 +1019,13 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         resourceManager.setOutputDirectory(new File(project.getBuild().getDirectory()))
 
-        log.debug("resourceManager outputDirectory is ${resourceManager.outputDirectory}")
-
-
-        log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
-
-        log.debug("outputFile is " + outputFile.getCanonicalPath())
-        log.debug("output Directory is " + spotbugsXmlOutputDirectory.getAbsolutePath())
-
-        log.debug("Temp File is " + tempFile.getCanonicalPath())
+        if (log.isDebugEnabled()) {
+            log.debug("resourceManager outputDirectory is ${resourceManager.outputDirectory}")
+            log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
+            log.debug("outputFile is " + outputFile.getCanonicalPath())
+            log.debug("output Directory is " + spotbugsXmlOutputDirectory.getAbsolutePath())
+            log.debug("Temp File is " + tempFile.getCanonicalPath())
+        }
 
         def ant = new AntBuilder()
 


### PR DESCRIPTION
On newer Java versions the following log statement triggers illegal reflective operation warnings:

    log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")

Since this is debug logging, the illegal operation can be prevented most of the time by only executing the operation when debug logging is enabled.

Related to: https://github.com/spotbugs/spotbugs-maven-plugin/issues/132