### PR TITLE
[fix] cp1252 is invalid, use 'windows-1252' instead

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1128,9 +1128,13 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 outputFile.createNewFile()
 
                 def writer = outputFile.newWriter(effectiveEncoding)
-				
-                writer.write "<?xml version=\"1.0\" encoding=\"" + effectiveEncoding + "\"?>"
-				
+
+                if (effectiveEncoding.equalsIgnoreCase("Cp1252")) {
+                    writer.write "<?xml version=\"1.0\" encoding=\"windows-1252\"?>"
+                } else {
+                    writer.write "<?xml version=\"1.0\" encoding=\"" + effectiveEncoding.toLowerCase(Locale.ENGLISH) + "\"?>"
+                }
+
                 writer.write "\n"
 
                 writer << xmlBuilder.bind { mkp.yield path }


### PR DESCRIPTION
Fixes final issues with xml output on file as requested per multiple tickets and resolved in PR for linux but needed a bit extra for windows + a fix to casing.