### PR TITLE
[fix] MFINDBUGS-145 needs site plugin 3.6 but needs doxia upgraded

### DIFF
--- a/src/it/MFINDBUGS-145/pom.xml
+++ b/src/it/MFINDBUGS-145/pom.xml
@@ -64,6 +64,54 @@
             </plugin>
           </reportPlugins>
         </configuration>
+        <!-- Jdk14 and above requires doxia be upgraded and allows test to still use old site otherwise test must be deleted -->
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-sink-api</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-xhtml</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-apt</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-xdoc</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-fml</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-markdown</artifactId>
+            <version>@doxiaVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-decoration-model</artifactId>
+            <version>@doxiaSiteToolsVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-site-renderer</artifactId>
+            <version>@doxiaSiteToolsVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-integration-tools</artifactId>
+            <version>@doxiaSiteToolsVersion@</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
For jdk 14 and above, doxia needs upgraded to work.  This seemed to come and go as jdk 14 was going through updates.  It is now in rampdown and latest openjdk which is listed as oracle and probably close to last build now fails again and can be confirmed on both linux and windows.  While jdk 15 still passes, it is more likely due to that not being jdk 15 really other than adjustments to overall product to indicate such.  In otherwords, it is unlikley to have the hard requirements of jdk 14 still for the most part.