### PR TITLE
Raise maven requirement to 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <mavenTransferVersion>0.12.0</mavenTransferVersion>
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>
-    <mavenVersion>3.5.0</mavenVersion> <!-- Version 3.5.3+ introduces issues for many users of spotbugs that cannot upgrade maven to latest -->
+    <mavenVersion>3.5.2</mavenVersion> <!-- Version 3.5.3+ introduces issues for many users of spotbugs that cannot upgrade maven to latest -->
 
     <plexusContainerVersion>2.1.0</plexusContainerVersion>
     <plexusResourcesVersion>1.1.0</plexusResourcesVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <compilerPluginVersion>3.8.1</compilerPluginVersion>
     <findsecbugsVersion>1.10.1</findsecbugsVersion>
     <jxrPluginVersion>3.0.0</jxrPluginVersion>
-    <mavenSurefireVersion>3.0.0-M3</mavenSurefireVersion>
+    <mavenSurefireVersion>3.0.0-M4</mavenSurefireVersion>
     <jakartaeeApiVersion>8.0.0</jakartaeeApiVersion>
     <servletApiVersion>4.0.3</servletApiVersion>
     <sb-contribVersion>7.4.7</sb-contribVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>3.1.1</maven>
+    <maven>3.2.5</maven>
   </prerequisites>
 
   <scm>
@@ -129,7 +129,7 @@
     <doxiaVersion>1.9.1</doxiaVersion>
     <doxiaSiteToolsVersion>1.9.2</doxiaSiteToolsVersion>
 
-    <mavenCoreVersion>3.1.1</mavenCoreVersion>
+    <mavenCoreVersion>3.2.5</mavenCoreVersion>
     <mavenTransferVersion>0.12.0</mavenTransferVersion>
     <mavenReportingApiVersion>3.0</mavenReportingApiVersion>
     <mavenReportingVersion>3.0.0</mavenReportingVersion>


### PR DESCRIPTION
Will allow users a longer time with older maven versions but dropping support for versions prior to 3.2.5.