### PR TITLE
CheckMojo: introduce failThreshold

### DIFF
--- a/src/it/check-fail/verify.groovy
+++ b/src/it/check-fail/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( '[ERROR] High: Found reliance on default encoding in UserMistakes' ) 

--- a/src/it/check-failThreshold/invoker.properties
+++ b/src/it/check-failThreshold/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = failure

--- a/src/it/check-failThreshold/pom.xml
+++ b/src/it/check-failThreshold/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check</artifactId>
+  <name>check</name>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>true</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <failThreshold>High</failThreshold>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-failThreshold/verify.groovy
+++ b/src/it/check-failThreshold/verify.groovy
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( '[WARNING] Medium: Unused public or protected field:' )
+assert buildLog.text.contains( '[ERROR] High: Found reliance on default encoding in UserMistakes' )


### PR DESCRIPTION
Resolves #219

Notes:
- First I cleaned up the duplicate parsing of `outputFile` and the scoping of `bugCount` and `errorCount` (see first commit)
- The recent Groovy update from 3.0.3 to 3.0.4 kills your builds: https://travis-ci.org/github/spotbugs/spotbugs-maven-plugin/builds/690024559
  ```
  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-invoker-plugin:3.2.1:install (prepare-integration-test) on project spotbugs-maven-plugin: Execution prepare-integration-test of goal org.apache.maven.plugins:maven-invoker-plugin:3.2.1:install failed: Plugin org.apache.maven.plugins:maven-invoker-plugin:3.2.1 or one of its dependencies could not be resolved: Could not find artifact org.testng:testng:jar:7.2.0 in google-maven-central (https://maven-central.storage-download.googleapis.com/maven2/) -> [Help 1]
  ```
  I get the same error locally ~which is why this change is not in my PR branch (based on https://github.com/spotbugs/spotbugs-maven-plugin/commit/689c796ac24009e2f79a01fc7f48f608cf13ae67 instead).~ (see first comment)
- This PR also adds a priority prefix to the log message:
  Before:
  ```
  [ERROR] Overwritten increment in UselessAssignments.oops() [UselessAssignments] At UselessAssignments.java:[line 30] DLS_OVERWRITTEN_INCREMENT
  ```
  With this PR:
  ```
  [ERROR] High: Overwritten increment in UselessAssignments.oops() [UselessAssignments] At UselessAssignments.java:[line 30] DLS_OVERWRITTEN_INCREMENT
  ``` 