### PR TITLE
[pom] Exclude groovy testng as we do not use it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -836,6 +836,13 @@
                 <artifactId>groovy-all</artifactId>
                 <version>${groovyVersion}</version>
                 <type>pom</type>
+                <exclusions>
+                    <!-- See 'addendum for 3.0.4 https://groovy-lang.org/releasenotes/groovy-3.0.html -->
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-testng</artifactId>
+                    </exclusion>
+                </exclusions>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
see https://groovy-lang.org/releasenotes/groovy-3.0.html due to incorrectly upgrading too soon.  While testng showed 7.2.0 released, they have also since retrated the release so it was likely a problem in my opinion.