### PR TITLE
CheckMojo: reduce log to info when bug below threshold

### DIFF
--- a/src/it/check-failThreshold/verify.groovy
+++ b/src/it/check-failThreshold/verify.groovy
@@ -15,5 +15,5 @@
  */
 
 File buildLog = new File( basedir, 'build.log' )
-assert buildLog.text.contains( '[WARNING] Medium: Unused public or protected field:' )
+assert buildLog.text.contains( '[INFO] Medium: Unused public or protected field:' )
 assert buildLog.text.contains( '[ERROR] High: Found reliance on default encoding in UserMistakes' )

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo.groovy
@@ -548,7 +548,7 @@ class SpotbugsViolationCheckMojo extends AbstractMojo {
                         bugCountAboveThreshold += 1
                         log.error(logMsg)
                     } else {
-                        log.warn(logMsg)
+                        log.info(logMsg)
                     }
                 }
 


### PR DESCRIPTION
The differentiated logging I introduced in #222 is actually a bit overzealous for bugs that are below the threshold.

That warning should be info instead and this is what this PR is changing.