### PR TITLE
Add IT test to check excludeFiltersFile duplications on multi-module projects

### DIFF
--- a/src/it/check-multi-filter-dups/invoker.properties
+++ b/src/it/check-multi-filter-dups/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/check-multi-filter-dups/module1/pom.xml
+++ b/src/it/check-multi-filter-dups/module1/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>check-multi-parent-relative-path</artifactId>
+    <version>testing</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>module1</artifactId>
+  <name>module1</name>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-multi-filter-dups/module2/pom.xml
+++ b/src/it/check-multi-filter-dups/module2/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>check-multi-parent-relative-path</artifactId>
+    <version>testing</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>module2</artifactId>
+  <name>module2</name>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-multi-filter-dups/pom.xml
+++ b/src/it/check-multi-filter-dups/pom.xml
@@ -51,10 +51,6 @@
       </plugin>
     </plugins>
   </build>
-
-  <properties>
-    <project.parent.relativePath>..</project.parent.relativePath>
-  </properties>
 </project>
 
 

--- a/src/it/check-multi-filter-dups/pom.xml
+++ b/src/it/check-multi-filter-dups/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check-multi-parent-relative-path</artifactId>
+  <name>check-multi-parent-relative-path</name>
+  <packaging>pom</packaging>
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <failOnError>false</failOnError>
+          <excludeFilterFile>${project.parent.relativePath}/src/main/config/spotbugs-exclude-filters.xml</excludeFilterFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <project.parent.relativePath>..</project.parent.relativePath>
+  </properties>
+</project>
+
+

--- a/src/it/check-multi-filter-dups/src/main/config/spotbugs-exclude-filters.xml
+++ b/src/it/check-multi-filter-dups/src/main/config/spotbugs-exclude-filters.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>

--- a/src/it/check-multi-filter-dups/verify.groovy
+++ b/src/it/check-multi-filter-dups/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+//  check module 1
+
+File spotbugXmlInModule = new File(basedir, "module1/src/main/config/spotbugs-exclude-filters.xml")
+assert !spotbugXmlInModule.exists()
+
+
+//  check module 2
+
+spotbugXmlInModule = new File(basedir, "module2/src/main/config/spotbugs-exclude-filters.xml")
+assert !spotbugXmlInModule.exists()
+


### PR DESCRIPTION
Related to #281 

An IT test has been created to cause and detect the issue. This test checks the existence of the excludeFiltersFile provided on the parent POM in each submodule, when a `relativePath` is used to declare it, taken the specific case from the info and examples provided in #281.