### PR TITLE
[travis] Drop jdk 16, 15, and 8 as these are done in actions now

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -3,7 +3,7 @@ name: SonarCloud
 on:
   push:
     branches:
-      - master
+      - spotbugs
 
 jobs:
   build:

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -3,7 +3,7 @@ name: Sonatype
 on:
   push:
     branches:
-      - master
+      - spotbugs
 
 jobs:
   build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ dist: bionic
 language: java
 
 jdk:
-  - openjdk16
-  - openjdk15
   - openjdk11
-  - openjdk8
 
 env:
   global:


### PR DESCRIPTION
Will eventually drop travis entirely once all pieces are up to date.