### PR TITLE
Revert fix #238 and correctly handle windows as it was only handling linux type line endings

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
@@ -25,8 +25,6 @@ import org.codehaus.plexus.resource.loader.FileResourceLoader
 import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.util.FileUtils
 
-import java.nio.file.Paths
-
 final class ResourceHelper {
 
     Log log
@@ -55,11 +53,12 @@ final class ResourceHelper {
         String location = null
         String artifact = resource
 
-        def file = new File(resource)
+        if (resource.indexOf(SpotBugsInfo.FORWARD_SLASH) != -1) {
+            artifact = resource.substring(resource.lastIndexOf(SpotBugsInfo.FORWARD_SLASH) + 1)
+        }
 
-        if (file.exists()) {
-            artifact = file.getName()
-            location = file.getAbsolutePath()
+        if (resource.indexOf(SpotBugsInfo.FORWARD_SLASH) != -1) {
+            location = resource.substring(0, resource.lastIndexOf(SpotBugsInfo.FORWARD_SLASH))
         }
 
         // replace all occurrences of the following characters:  ? : & =

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
@@ -53,12 +53,22 @@ final class ResourceHelper {
         String location = null
         String artifact = resource
 
+        // Linux Checks
         if (resource.indexOf(SpotBugsInfo.FORWARD_SLASH) != -1) {
             artifact = resource.substring(resource.lastIndexOf(SpotBugsInfo.FORWARD_SLASH) + 1)
         }
 
         if (resource.indexOf(SpotBugsInfo.FORWARD_SLASH) != -1) {
             location = resource.substring(0, resource.lastIndexOf(SpotBugsInfo.FORWARD_SLASH))
+        }
+
+        // Windows Checks
+        if (resource.indexOf(SpotBugsInfo.BACKWARD_SLASH) != -1) {
+            artifact = resource.substring(resource.lastIndexOf(SpotBugsInfo.BACKWARD_SLASH) + 1)
+        }
+
+        if (resource.indexOf(SpotBugsInfo.BACKWARD_SLASH) != -1) {
+            location = resource.substring(0, resource.lastIndexOf(SpotBugsInfo.BACKWARD_SLASH))
         }
 
         // replace all occurrences of the following characters:  ? : & =

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
@@ -79,6 +79,8 @@ interface SpotBugsInfo {
 
     static final String FORWARD_SLASH = '/'
 
+    static final String BACKWARD_SLASH = '\\'
+
     /**
      * The character to separate URL tokens.
      *

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
@@ -77,6 +77,8 @@ interface SpotBugsInfo {
 
     static final String COMMA = ","
 
+    static final String FORWARD_SLASH = '/'
+
     /**
      * The character to separate URL tokens.
      *


### PR DESCRIPTION
Original problem was C_ in target directory looking out of place.  The change in #238 caused it to copy all resources into exact locations which under certain setup would cause source path to incorrectly be changed.  After an integration test was added to confirm this, the logic was reverted here and subsequent change to handle windows in additional to linux.  Now no more nested still but the add on jars like fb-contrib are copied into target.  A separate ticket has been opened to address that as that seems wrong.  All other copies seem appropriate.