### PR TITLE
Fix #306, correctly prints a trace of classes analyzed to standard output.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1062,7 +1062,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
 
             if (debug || trace) {
-                sysproperty(key: "spotbugs.debug", value: true)
+                sysproperty(key: "findbugs.debug", value: true)
             }
 
             classpath() {


### PR DESCRIPTION
Hi,
fixes #306 
I found that there was an inconsistency between [spotbugs source code](https://github.com/spotbugs/spotbugs/blob/a6f9acb2932b54f5b70ea8bc206afb552321a222/spotbugs/src/main/java/edu/umd/cs/findbugs/FindBugs2.java#L102) and [spotbugs-maven-plugin source code](https://github.com/spotbugs/spotbugs-maven-plugin/blob/spotbugs/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy#L1065). 
If spotbugs-maven-plugin wants to turn on Spotbugs debugging, the key of the system property is supposed to be set as 'findbugs.debug' instead of 'spotbugs.debug' as shown in the spotbugs source code.

[after-modified.log](https://github.com/spotbugs/spotbugs-maven-plugin/files/6168886/after-modified.log)
[before-modified.log](https://github.com/spotbugs/spotbugs-maven-plugin/files/6168887/before-modified.log)



