### PR TITLE
Add configuration parameter systemPropertyVariables

### DIFF
--- a/src/it/systemPropertyVariables/invoker.properties
+++ b/src/it/systemPropertyVariables/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/systemPropertyVariables/pom.xml
+++ b/src/it/systemPropertyVariables/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>systemPropertyVariables</artifactId>
+  <name>systemPropertyVariables</name>
+  <packaging>jar</packaging>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <findsecbugs.taint.taintedsystemvariables>true
+            </findsecbugs.taint.taintedsystemvariables>
+          </systemPropertyVariables>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>@findsecbugsVersion@</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/systemPropertyVariables/verify.groovy
+++ b/src/it/systemPropertyVariables/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( '[java] INFO: System variables are considered to be tainted' ) 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -520,6 +520,16 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     @Parameter(property = "spotbugs.userPrefs")
     String userPrefs
 
+    /**
+     * <p>
+     * System properties to set in the VM (or the forked VM if fork is enabled).
+     * <p>
+     *
+     * @since 4.2.4
+     */
+    @Parameter(property = "spotbugs.systemPropertyVariables")
+    Map<String, String> systemPropertyVariables
+
     int bugCount
 
     int errorCount
@@ -1077,6 +1087,11 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             spotbugsArgs.each { spotbugsArg ->
                 log.debug("Spotbugs arg is ${spotbugsArg}")
                 arg(value: spotbugsArg)
+            }
+
+            systemPropertyVariables.each { sysProp ->
+                log.debug("System property ${sysProp.key} is ${sysProp.value}")
+                sysproperty(key: sysProp.key, value: sysProp.value)
             }
 
         }


### PR DESCRIPTION
Some SpotBugs plugins such as FindSecBugs take their options using
system properties. These system properties can be set either before
calling Maven (as environmental variables) or as the parameter to Maven
(using the -D command line option). However, for many users the best way
is to include these option to pom.xml. This patch makes it possible for
the SpotBugs Maven plugin using configuration parameter
systemPropertyVariables.