### PR TITLE
Add support for SARIF format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .project
 .settings
 target/
+.idea/
 *.ipr
 *.iws
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-json</artifactId>
+      <version>${groovyVersion}</version>
+      <classifier>indy</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
       <version>${mavenReportingVersion}</version>

--- a/src/it/sarif-1/invoker.properties
+++ b/src/it/sarif-1/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile compiler:testCompile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/sarif-1/pom.xml
+++ b/src/it/sarif-1/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>sarif-1</artifactId>
+  <name>sarif-1</name>
+  <packaging>jar</packaging>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxrPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <sarifOutput>true</sarifOutput> <!-- SARIF is enabled here -->
+          <includeTests>true</includeTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/sarif-1/verify.groovy
+++ b/src/it/sarif-1/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonSlurper
+
+def effortLevel = 'default'
+
+
+File spotbugSarifFile = new File(basedir, 'target/spotbugsSarif.json')
+assert spotbugSarifFile.exists()
+
+
+println '**********************************'
+println "Checking SARIF file"
+println '**********************************'
+
+def path = new JsonSlurper().parse(spotbugSarifFile)
+
+def results = path.runs.results[0]
+println "BugInstance size is ${results.size()}"
+
+
+assert results.size() > 0

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1084,7 +1084,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         ant.java(classname: "edu.umd.cs.findbugs.FindBugs2", inputstring: getSpotbugsAuxClasspath(), fork: "${fork}", failonerror: "true", clonevm: "false", timeout: "${timeout}", maxmemory: "${maxHeap}m") {
-            //this.executeSpotbugs()
+
             log.debug("File Encoding is " + effectiveEncoding)
 
             sysproperty(key: "file.encoding", value: effectiveEncoding)

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1060,11 +1060,11 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         resourceManager.setOutputDirectory(new File(project.getBuild().getDirectory()))
 
         if (log.isDebugEnabled()) {
-            log.debug("resourceManager outputDirectory is ${resourceManager.outputDirectory}")
-            log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
-            log.debug("outputFile is " + outputFile.getCanonicalPath())
-            log.debug("output Directory is " + spotbugsXmlOutputDirectory.getAbsolutePath())
-            log.debug("Temp File is " + xmlTempFile.getCanonicalPath())
+            log.debug("resourceManager.outputDirectory is ${resourceManager.outputDirectory}")
+            log.debug("Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
+            log.debug("outputFile is ${outputFile.getCanonicalPath()}")
+            log.debug("output Directory is ${spotbugsXmlOutputDirectory.getAbsolutePath()}")
+            log.debug("TempFile is ${(sarifOutput ? sarifTempFile : xmlTempFile).getCanonicalPath()}");
         }
 
         def ant = new AntBuilder()

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1040,13 +1040,13 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         long startTime, duration
 
         File xmlTempFile = new File("${project.build.directory}/spotbugsTemp.xml")
-        File sarifTempFile = new File("${project.build.directory}/spotbugsSarif.json")
+        File sarifFile = new File("${project.build.directory}/spotbugsSarif.json")
 
         if (xmlOutput || !sarifOutput) {
             forceFileCreation(xmlTempFile)
         }
         else {
-            forceFileCreation(sarifTempFile)
+            forceFileCreation(sarifFile)
         }
 
 
@@ -1064,7 +1064,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             log.debug("Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
             log.debug("outputFile is ${outputFile.getCanonicalPath()}")
             log.debug("output Directory is ${spotbugsXmlOutputDirectory.getAbsolutePath()}")
-            log.debug("TempFile is ${(sarifOutput ? sarifTempFile : xmlTempFile).getCanonicalPath()}");
+            log.debug("TempFile is ${(sarifOutput ? sarifFile : xmlTempFile).getCanonicalPath()}");
         }
 
         def ant = new AntBuilder()
@@ -1075,7 +1075,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             startTime = System.nanoTime()
         }
 
-        def spotbugsArgs = !sarifOutput ? getSpotbugsArgs(xmlTempFile) : getSpotbugsArgs(sarifTempFile)
+        def spotbugsArgs = !sarifOutput ? getSpotbugsArgs(xmlTempFile) : getSpotbugsArgs(sarifFile)
 
         def effectiveEncoding = System.getProperty("file.encoding", "UTF-8")
 
@@ -1193,9 +1193,9 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         }
 
-        if(sarifTempFile && sarifOutput) {
-            if (sarifTempFile.size() > 0) {
-                def path = new JsonSlurper().parse(sarifTempFile)
+        if(sarifFile && sarifOutput) {
+            if (sarifFile.size() > 0) {
+                def path = new JsonSlurper().parse(sarifFile)
 
                 try {
 
@@ -1203,7 +1203,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                     log.debug("BugInstance size is ${results.size()}")
                 }
                 catch (Exception e) {
-                    log.error("Unexpected format for the file $sarifTempFile",e)
+                    log.error("Unexpected format for the file $sarifFile",e)
                 }
             }
         }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -19,10 +19,9 @@ package org.codehaus.mojo.spotbugs
  * under the License.
  */
 
+import groovy.json.JsonSlurper
 import groovy.xml.XmlSlurper
 import groovy.xml.StreamingMarkupBuilder
-
-import org.apache.maven.artifact.Artifact
 import org.apache.maven.artifact.repository.ArtifactRepository
 
 import org.apache.maven.doxia.siterenderer.Renderer
@@ -32,8 +31,7 @@ import org.apache.maven.execution.MavenSession
 
 import org.apache.maven.plugin.MojoExecutionException
 
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.LifecyclePhase
+import org.apache.maven.plugins.annotations.Component
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.plugins.annotations.ResolutionScope
@@ -46,7 +44,6 @@ import org.apache.maven.repository.RepositorySystem
 
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver
 import org.codehaus.plexus.resource.ResourceManager
-import org.codehaus.plexus.resource.loader.FileResourceCreationException
 import org.codehaus.plexus.resource.loader.FileResourceLoader
 
 /**
@@ -70,6 +67,16 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      */
     @Parameter(defaultValue = "false", property = "spotbugs.xmlOutput", required = true)
     boolean xmlOutput
+
+    /**
+     * Turn on and off SARIF output of the Spotbugs report.
+     * SARIF is a JSON format standardize for all code scanning tools.
+     * https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/sarif-support-for-code-scanning
+     *
+     * @since 4.3.1
+     */
+    @Parameter(defaultValue = "false", property = "spotbugs.sarifOutput", required = true)
+    boolean sarifOutput
 
     /**
      * Specifies the directory where the xml output will be generated.
@@ -845,7 +852,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             args << resourceHelper.getResourceFile(userPrefs.trim())
         }
 
-        args << "-xml:withMessages"
+        if(!sarifOutput) {
+            args << "-xml:withMessages"
+        }
+        else {
+            args << "-sarif"
+        }
 
         args << "-auxclasspathFromInput"
 
@@ -1001,6 +1013,21 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     }
 
     /**
+     * For the file creation by creating the file AND folder if needed.
+     * The file created will be empty.
+     *
+     * @param file Destination file to create.
+     */
+    private void forceFileCreation(File file) {
+        if (file.exists()) {
+            file.delete()
+        }
+
+        file.getParentFile().mkdirs()
+        file.createNewFile()
+    }
+
+    /**
      * Set up and run the Spotbugs engine.
      *
      * @param locale
@@ -1012,14 +1039,16 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         log.debug("****** SpotBugsMojo executeSpotbugs *******")
         long startTime, duration
 
-        File tempFile = new File("${project.build.directory}/spotbugsTemp.xml")
+        File xmlTempFile = new File("${project.build.directory}/spotbugsTemp.xml")
+        File sarifTempFile = new File("${project.build.directory}/spotbugsSarif.json")
 
-        if (tempFile.exists()) {
-            tempFile.delete()
+        if (xmlOutput || !sarifOutput) {
+            forceFileCreation(xmlTempFile)
+        }
+        else {
+            forceFileCreation(sarifTempFile)
         }
 
-        tempFile.getParentFile().mkdirs()
-        tempFile.createNewFile()
 
         outputEncoding = outputEncoding ?: 'UTF-8'
 
@@ -1035,7 +1064,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts.toString()}")
             log.debug("outputFile is " + outputFile.getCanonicalPath())
             log.debug("output Directory is " + spotbugsXmlOutputDirectory.getAbsolutePath())
-            log.debug("Temp File is " + tempFile.getCanonicalPath())
+            log.debug("Temp File is " + xmlTempFile.getCanonicalPath())
         }
 
         def ant = new AntBuilder()
@@ -1046,7 +1075,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             startTime = System.nanoTime()
         }
 
-        def spotbugsArgs = getSpotbugsArgs(tempFile)
+        def spotbugsArgs = !sarifOutput ? getSpotbugsArgs(xmlTempFile) : getSpotbugsArgs(sarifTempFile)
 
         def effectiveEncoding = System.getProperty("file.encoding", "UTF-8")
 
@@ -1055,7 +1084,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         ant.java(classname: "edu.umd.cs.findbugs.FindBugs2", inputstring: getSpotbugsAuxClasspath(), fork: "${fork}", failonerror: "true", clonevm: "false", timeout: "${timeout}", maxmemory: "${maxHeap}m") {
-
+            //this.executeSpotbugs()
             log.debug("File Encoding is " + effectiveEncoding)
 
             sysproperty(key: "file.encoding", value: effectiveEncoding)
@@ -1103,10 +1132,10 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         log.info("Done SpotBugs Analysis....")
 
-        if (tempFile.exists()) {
+        if (xmlTempFile.exists() && !sarifOutput) {
 
-            if (tempFile.size() > 0) {
-                def path = new XmlSlurper().parse(tempFile)
+            if (xmlTempFile.size() > 0) {
+                def path = new XmlSlurper().parse(xmlTempFile)
 
                 def allNodes = path.depthFirst().collect { it }
 
@@ -1159,9 +1188,24 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
 
             if (!log.isDebugEnabled()) {
-                tempFile.delete()
+                xmlTempFile.delete()
             }
 
+        }
+
+        if(sarifTempFile && sarifOutput) {
+            if (sarifTempFile.size() > 0) {
+                def path = new JsonSlurper().parse(sarifTempFile)
+
+                try {
+
+                    def results = path.runs.results[0]
+                    log.debug("BugInstance size is ${results.size()}")
+                }
+                catch (Exception e) {
+                    log.error("Unexpected format for the file $sarifTempFile",e)
+                }
+            }
         }
 
     }


### PR DESCRIPTION
This change allow the Maven plugin to export the SARIF format - already supported by SpotBugs- to the build directory.
It reuse the same directory configured to export the XML file.
Add the moment, it can only export XML or SARIF (JSON) not both.

By default the report will be placed in `target/spotbugsSarif.json`.

### Configuration

It can be configure inline with:
`-Dspotbugs.sarifOutput=true`

or with XML configuration.

### Objective

The key goal is to easily allow the configuration of Github workflow with SARIF upload.
https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/uploading-a-sarif-file-to-github