### PR TITLE
SARIF support for Github action : Add the option to transform relative path to complete path

### DIFF
--- a/src/it/sarif-2/invoker.properties
+++ b/src/it/sarif-2/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile compiler:testCompile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/sarif-2/pom.xml
+++ b/src/it/sarif-2/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>sarif-2</artifactId>
+  <name>sarif-2</name>
+  <packaging>jar</packaging>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxrPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <sarifOutput>true</sarifOutput> <!-- SARIF is enabled here -->
+          <sarifFullPath>true</sarifFullPath> <!-- Full path expansion enabled -->
+          <includeTests>true</includeTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/sarif-2/verify.groovy
+++ b/src/it/sarif-2/verify.groovy
@@ -41,7 +41,7 @@ for (result in slurpedResult.runs.results[0]) {
     for (loc in result.locations) {
         String location = normalizePath(loc.physicalLocation.artifactLocation.uri)
         //Making sure that the path was expanded
-        assert location.contains("src/it-src/test/java") : "$location does not contain 'src/it-src/test/java'"
+        assert location.contains("src/it-src/test/java") || location.contains("src/java") : "$location does not contain 'src/it-src/test/java'"
     }
 }
 

--- a/src/it/sarif-2/verify.groovy
+++ b/src/it/sarif-2/verify.groovy
@@ -27,6 +27,11 @@ println '**********************************'
 println "Checking SARIF file"
 println '**********************************'
 
+
+def String normalizePath(String path) {
+	return path.replaceAll("\\\\","/");
+}
+
 def slurpedResult = new JsonSlurper().parse(spotbugSarifFile)
 
 def results = slurpedResult.runs.results[0]
@@ -34,9 +39,9 @@ def results = slurpedResult.runs.results[0]
 for (result in slurpedResult.runs.results[0]) {
 
     for (loc in result.locations) {
-        String location = loc.physicalLocation.artifactLocation.uri
+        String location = normalizePath(loc.physicalLocation.artifactLocation.uri)
         //Making sure that the path was expanded
-        assert location.contains("src/it-src/test/java")
+        assert location.contains("src/it-src/test/java") : "$location does not contain 'src/it-src/test/java'"
     }
 }
 

--- a/src/it/sarif-2/verify.groovy
+++ b/src/it/sarif-2/verify.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonSlurper
+
+def effortLevel = 'default'
+
+
+File spotbugSarifFile = new File(basedir, 'target/spotbugsSarif.json')
+assert spotbugSarifFile.exists()
+
+
+println '**********************************'
+println "Checking SARIF file"
+println '**********************************'
+
+def slurpedResult = new JsonSlurper().parse(spotbugSarifFile)
+
+def results = slurpedResult.runs.results[0]
+
+for (result in slurpedResult.runs.results[0]) {
+
+    for (loc in result.locations) {
+        String location = loc.physicalLocation.artifactLocation.uri
+        //Making sure that the path was expanded
+        assert location.contains("src/it-src/test/java")
+    }
+}
+
+
+println "BugInstance size is ${results.size()}"
+
+
+assert results.size() > 0

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
@@ -1,0 +1,144 @@
+package org.codehaus.mojo.spotbugs
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.Resource
+import org.apache.maven.project.MavenProject
+
+import java.nio.file.Paths
+
+/**
+ * Utility class used to transform path relative to the <b>source directory</b>
+ * to their path relative to the <b>root directory</b>.
+ */
+class SourceFileIndexer {
+
+    /**
+     * List of source files found in the current Maven project
+     */
+    private List<String> allSourceFiles;
+
+    /**
+     * Initialize the complete list of source files with their
+     *
+     * @param project Reference to the Maven project to get the list of source directories
+     * @param session Reference to the Maven session used to get the location of the root directory
+     */
+    protected void buildListSourceFiles(MavenProject project, MavenSession session) {
+
+        //String basePath = project.basedir.absolutePath
+        String basePath = session.getExecutionRootDirectory()
+
+        def allSourceFiles = new ArrayList<>()
+        //Resource
+        for(Resource r in project.getResources()) {
+            scanDirectory(new File(r.directory), allSourceFiles, basePath)
+        }
+        for(Resource r in project.getTestResources()) {
+            scanDirectory(new File(r.directory), allSourceFiles, basePath)
+        }
+        //Source files
+        for(String sourceRoot in project.getCompileSourceRoots()) {
+            scanDirectory(new File(sourceRoot), allSourceFiles, basePath)
+        }
+        for(String sourceRoot in project.getTestCompileSourceRoots()) {
+            scanDirectory(new File(sourceRoot), allSourceFiles, basePath)
+        }
+
+        for(String sourceRoot in project.getScriptSourceRoots()) {
+            scanDirectory(new File(sourceRoot), allSourceFiles, basePath)
+        }
+
+        //While not perfect, add the following paths will add basic support for Kotlin and Groovy
+        scanDirectory(new File(project.getBasedir(),"src/main/webapp"), allSourceFiles, basePath)
+        scanDirectory(new File(project.getBasedir(),"src/main/groovy"), allSourceFiles, basePath)
+        scanDirectory(new File(project.getBasedir(),"src/main/kotlin"), allSourceFiles, basePath)
+
+        this.allSourceFiles = allSourceFiles
+    }
+
+    /**
+     * Recursively scan the directory given and add all files found to the files array list.
+     * The base directory will be truncated from the path stored.
+     *
+     * @param directory Directory to scan
+     * @param files ArrayList where files found will be stored
+     * @param baseDirectory This part will be truncated from path stored
+     * @throws IOException
+     */
+    private void scanDirectory(File directory,List<String> files,String baseDirectory) throws IOException {
+
+        if(directory.exists()) {
+            for(File child : directory.listFiles()) {
+                if(child.isDirectory()) {
+                    scanDirectory(child,files,baseDirectory);
+                }
+                else {
+                    if(child.canonicalPath.startsWith(baseDirectory)) {
+                        //The project will not be at the root of our file system.
+                        //It will most likely be stored in a work directory.
+                        // /work/project-code-to-scan/src/main/java/File.java => src/main/java/File.java
+                        // (Here baseDirectory is /work/project-code-to-scan/)
+                        String relativePath = Paths.get(baseDirectory).relativize(Paths.get(child.path))
+                        files.add(normalizePath(relativePath))
+                    }
+                    else {
+                        files.add(normalizePath(child.path))
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Normalize path to use forward slash.
+     * This will facilitate searches.
+     *
+     * @param path Path to clean up
+     * @return Path safe to use for comparison
+     */
+    private String normalizePath(String path) {
+        return path.replaceAll("\\\\","/");
+    }
+
+    /**
+     * Transform partial path to complete path
+     *
+     * @param filename Partial name to search
+     * @return Complete path found. Null is not found!
+     */
+    protected String searchActualFilesLocation(String filename) {
+
+        if(allSourceFiles == null) {
+            throw new RuntimeException("Source files cache must be built prior to searches.")
+        }
+
+        for(String fileFound in allSourceFiles) {
+
+            if(fileFound.endsWith(filename)) {
+                return fileFound
+            }
+
+        }
+
+        return null //Not found
+    }
+}

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
@@ -45,7 +45,7 @@ class SourceFileIndexer {
     protected void buildListSourceFiles(MavenProject project, MavenSession session) {
 
         //String basePath = project.basedir.absolutePath
-        String basePath = session.getExecutionRootDirectory()
+        String basePath = normalizePath(session.getExecutionRootDirectory())
 
         def allSourceFiles = new ArrayList<>()
         //Resource
@@ -92,16 +92,20 @@ class SourceFileIndexer {
                     scanDirectory(child,files,baseDirectory);
                 }
                 else {
-                    if(child.canonicalPath.startsWith(baseDirectory)) {
+                    String newSourceFile = normalizePath(child.canonicalPath)
+                    if(newSourceFile.startsWith(baseDirectory)) {
                         //The project will not be at the root of our file system.
                         //It will most likely be stored in a work directory.
                         // /work/project-code-to-scan/src/main/java/File.java => src/main/java/File.java
                         // (Here baseDirectory is /work/project-code-to-scan/)
-                        String relativePath = Paths.get(baseDirectory).relativize(Paths.get(child.path))
+                        String relativePath = Paths.get(baseDirectory).relativize(Paths.get(newSourceFile))
                         files.add(normalizePath(relativePath))
                     }
                     else {
-                        files.add(normalizePath(child.path))
+                        //Use the full path instead:
+                        //This will occurs in many cases including when the pom.xml is
+                        // not in the same directory tree as the sources.
+                        files.add(newSourceFile)
                     }
                 }
             }


### PR DESCRIPTION
Github code scanning required path relative to the root of the repository.

With the new option `spotbugs.sarifFullPath`
```
mvn com.github.spotbugs:spotbugs-maven-plugin:4.3.1-SNAPSHOT:spotbugs -Dspotbugs.sarifOutput=true -Dspotbugs.sarifFullPath=true
```

- [x] Implementation
- [x] Test with single module and multi-modules
- [x] Document code
- [x] Integration tests (soon to be complete)