### PR TITLE
Add verify and spotbugs to m2e setup following m2e code quality plugin and added information on m2e code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ Known issues
 The security manager is turned off by default in jdk 18/19 and scheduled from removal in a future java release, therefore to use this plugin with jdk 18/19, the security manager may need turned back on using ```JAVA_OPTS``` to ```-Djava.security.manager=allow```.  See [groovy](https://groovy-lang.org/releasenotes/groovy-4.0.html) for more details.
 
 If using groovy with same group id (```org.codehaus.groovy 3.x``` or before or ```org.apache.groovy 4.x or above```), an error may occur if not on same version. To alleviate that, make sure groovy artifacts are defined in ```dependency management``` in order to force the loaded version correctly on your usage.
+
+
+## Eclipse m2e Integration ##
+
+The plugin cycles controlled by Eclipse require compilation phase for m2e without further help.  This plugin runs verify and during site generation.  Therefore Eclipse m2e will show up but not do anything with this plugin alone.  In order to have proper execution within Ecipse m2e, use [m2e-code-quality](https://github.com/m2e-code-quality/m2e-code-quality) plugin for spotbugs.

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,6 +4,8 @@
             <pluginExecutionFilter>
                 <goals>
                     <goal>check</goal>
+                    <goal>spotbugs</goal>
+                    <goal>verify</goal>
                 </goals>
             </pluginExecutionFilter>
             <action>


### PR DESCRIPTION
By itself, our plugin doesn't run in a phase that Eclipse understands for m2e.  Therefore we need to use m2e-code-quality which appears to further use [m2e-discovery-catalog](https://github.com/takari/m2e-discovery-catalog).  I have added a note to use m2e-code-quality to provision the support.  Further our setup at least aligns now to the mojos we have which matches up to m2e-code-quality.  See [m2e-code-quality](https://github.com/m2e-code-quality/m2e-code-quality) for more details.