### PR TITLE
add multi-file support to the maven spotbugs plugin

### DIFF
--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-other.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-other.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BugCollection sequence="0" release="" analysisTimestamp="1653586688929" version="4.7.0" timestamp="1653586685292">
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c7f9edd192cfef80d2e55dde64a514bc" rank="2" abbrev="INT" category="CORRECTNESS" priority="1" type="INT_BAD_COMPARISON_WITH_SIGNED_BYTE" instanceOccurrenceMax="0">
+    <ShortMessage>Bad comparison of signed byte</ShortMessage>
+    <LongMessage>Bad comparison of signed byte with 200 in AssumeUnsignedBytes.find200(byte[])</LongMessage>
+    <Class classname="AssumeUnsignedBytes" primary="true">
+      <SourceLine classname="AssumeUnsignedBytes" start="3" end="10" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java">
+        <Message>At AssumeUnsignedBytes.java:[lines 3-10]</Message>
+      </SourceLine>
+      <Message>In class AssumeUnsignedBytes</Message>
+    </Class>
+    <Method isStatic="false" classname="AssumeUnsignedBytes" signature="([B)I" name="find200" primary="true">
+      <SourceLine endBytecode="82" classname="AssumeUnsignedBytes" start="7" end="10" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java" startBytecode="0"/>
+      <Message>In method AssumeUnsignedBytes.find200(byte[])</Message>
+    </Method>
+    <Int role="INT_VALUE" value="200">
+      <Message>Value 200</Message>
+    </Int>
+    <SourceLine endBytecode="14" classname="AssumeUnsignedBytes" start="8" end="8" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java" startBytecode="14" primary="true">
+      <Message>At AssumeUnsignedBytes.java:[line 8]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c44f97bf502b32aba37c238aae4e404c" rank="14" abbrev="HE" category="BAD_PRACTICE" priority="1" type="HE_EQUALS_USE_HASHCODE" instanceOccurrenceMax="0">
+    <ShortMessage>Class defines equals() and uses Object.hashCode()</ShortMessage>
+    <LongMessage>UseOfNonHashableClassInHashDataStructure defines equals and uses Object.hashCode()</LongMessage>
+    <Class classname="UseOfNonHashableClassInHashDataStructure" primary="true">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure" start="3" end="24" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[lines 3-24]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure</Message>
+    </Class>
+    <Method isStatic="false" classname="UseOfNonHashableClassInHashDataStructure" signature="(Ljava/lang/Object;)Z" name="equals" primary="true">
+      <SourceLine endBytecode="51" classname="UseOfNonHashableClassInHashDataStructure" start="16" end="16" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java" startBytecode="0"/>
+      <Message>In method UseOfNonHashableClassInHashDataStructure.equals(Object)</Message>
+    </Method>
+    <SourceLine synthetic="true" endBytecode="51" classname="UseOfNonHashableClassInHashDataStructure" start="16" end="16" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java" startBytecode="0">
+      <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="a4564c101ee03f13b56ee6a6b66efd77" rank="5" abbrev="HE" category="CORRECTNESS" priority="1" type="HE_SIGNATURE_DECLARES_HASHING_OF_UNHASHABLE_CLASS" instanceOccurrenceMax="0">
+    <ShortMessage>Signature declares use of unhashable class in hashed construct</ShortMessage>
+    <LongMessage>UseOfNonHashableClassInHashDataStructure doesn't define a hashCode() method but it is used in a hashed context in UseOfNonHashableClassInHashDataStructure$UMap</LongMessage>
+    <Class classname="UseOfNonHashableClassInHashDataStructure$UMap" primary="true">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure$UMap</Message>
+    </Class>
+    <Class classname="UseOfNonHashableClassInHashDataStructure$UMap">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure$UMap</Message>
+    </Class>
+    <Type role="TYPE_UNHASHABLE" descriptor="LUseOfNonHashableClassInHashDataStructure;">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure" start="3" end="24" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[lines 3-24]</Message>
+      </SourceLine>
+      <Message>Unhashable class UseOfNonHashableClassInHashDataStructure </Message>
+    </Type>
+    <SourceLine synthetic="true" classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+      <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="e248f9d4626fdfcebf961d28bcbd1d88" cweid="563" rank="5" abbrev="DLS" category="CORRECTNESS" priority="1" type="DLS_OVERWRITTEN_INCREMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Overwritten increment</ShortMessage>
+    <LongMessage>Overwritten increment in UselessAssignments.oops()</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="()I" name="oops" primary="true">
+      <SourceLine endBytecode="88" classname="UselessAssignments" start="28" end="33" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method UselessAssignments.oops()</Message>
+    </Method>
+    <SourceLine endBytecode="12" classname="UselessAssignments" start="30" end="30" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="12" primary="true">
+      <Message>At UselessAssignments.java:[line 30]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c845f2f6bcbb54ef6993e667f2ab9f6a" rank="1" abbrev="SA" category="CORRECTNESS" priority="1" type="SA_FIELD_SELF_ASSIGNMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Self assignment of field</ShortMessage>
+    <LongMessage>Self assignment of field foo in new UselessAssignments(int, int)</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="(II)V" name="&lt;init&gt;" primary="true">
+      <SourceLine endBytecode="72" classname="UselessAssignments" start="14" end="20" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method new UselessAssignments(int, int)</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <LocalVariable role="LOCAL_VARIABLE_DID_YOU_MEAN" pc="0" name="?" register="1">
+      <Message>Did you mean to refer to the local variable ?</Message>
+    </LocalVariable>
+    <SourceLine endBytecode="9" classname="UselessAssignments" start="16" end="16" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="9" primary="true">
+      <Message>At UselessAssignments.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="48138b3b7d208c1dee75d30c88c3f630" rank="1" abbrev="SA" category="CORRECTNESS" priority="1" type="SA_FIELD_SELF_ASSIGNMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Self assignment of field</ShortMessage>
+    <LongMessage>Self assignment of field foo in UselessAssignments.oops()</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="()I" name="oops" primary="true">
+      <SourceLine endBytecode="88" classname="UselessAssignments" start="28" end="33" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method UselessAssignments.oops()</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <SourceLine endBytecode="25" classname="UselessAssignments" start="31" end="31" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="25" primary="true">
+      <Message>At UselessAssignments.java:[line 31]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="ef8d86e8b4ffe32c6b42c02f53d79967" rank="1" abbrev="UR" category="CORRECTNESS" priority="1" type="UR_UNINIT_READ" instanceOccurrenceMax="0">
+    <ShortMessage>Uninitialized read of field in constructor</ShortMessage>
+    <LongMessage>Uninitialized read of foo in new UselessAssignments(int, int)</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="(II)V" name="&lt;init&gt;" primary="true">
+      <SourceLine endBytecode="72" classname="UselessAssignments" start="14" end="20" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method new UselessAssignments(int, int)</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <LocalVariable role="LOCAL_VARIABLE_DID_YOU_MEAN" pc="0" name="?" register="1">
+      <Message>Did you mean to refer to the local variable ?</Message>
+    </LocalVariable>
+    <SourceLine endBytecode="6" classname="UselessAssignments" start="16" end="16" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="6" primary="true">
+      <Message>At UselessAssignments.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c605add53d7d36f5dea72b09c753696b" rank="19" abbrev="Dm" category="I18N" priority="1" type="DM_DEFAULT_ENCODING" instanceOccurrenceMax="0">
+    <ShortMessage>Reliance on default encoding</ShortMessage>
+    <LongMessage>Found reliance on default encoding in UserMistakes.main(String[]): new java.io.FileReader(String)</LongMessage>
+    <Class classname="UserMistakes" primary="true">
+      <SourceLine classname="UserMistakes" start="10" end="43" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java">
+        <Message>At UserMistakes.java:[lines 10-43]</Message>
+      </SourceLine>
+      <Message>In class UserMistakes</Message>
+    </Class>
+    <Method isStatic="true" classname="UserMistakes" signature="([Ljava/lang/String;)V" name="main" primary="true">
+      <SourceLine endBytecode="318" classname="UserMistakes" start="13" end="43" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="0"/>
+      <Message>In method UserMistakes.main(String[])</Message>
+    </Method>
+    <Method isStatic="false" role="METHOD_CALLED" classname="java.io.FileReader" signature="(Ljava/lang/String;)V" name="&lt;init&gt;">
+      <SourceLine endBytecode="68" classname="java.io.FileReader" start="60" end="61" sourcepath="java/io/FileReader.java" sourcefile="FileReader.java" startBytecode="0"/>
+      <Message>Called method new java.io.FileReader(String)</Message>
+    </Method>
+    <SourceLine endBytecode="57" classname="UserMistakes" start="26" end="26" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="57" primary="true">
+      <Message>At UserMistakes.java:[line 26]</Message>
+    </SourceLine>
+    <SourceLine role="SOURCE_LINE_ANOTHER_INSTANCE" endBytecode="111" classname="UserMistakes" start="37" end="37" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="111">
+      <Message>Another occurrence at UserMistakes.java:[line 37]</Message>
+    </SourceLine>
+  </BugInstance>
+</BugCollection>

--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-outputstream.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-outputstream.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BugCollection sequence="0" release="" analysisTimestamp="1653586688929" version="4.7.0" timestamp="1653586685292">
+  <BugInstance instanceOccurrenceNum="0" instanceHash="a7786a4e4e4b9291a71529139eda42d1" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject1(File, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/io/File;Ljava/lang/Object;)V" name="appendObject1" primary="true">
+      <SourceLine endBytecode="62" classname="AppendingToAnObjectOutputStream" start="14" end="17" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject1(File, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="13" classname="AppendingToAnObjectOutputStream" start="14" end="14" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="13" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 14]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="291247b70690f65de576af5f247deda2" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject2(File, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/io/File;Ljava/lang/Object;)V" name="appendObject2" primary="true">
+      <SourceLine endBytecode="69" classname="AppendingToAnObjectOutputStream" start="21" end="24" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject2(File, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="20" classname="AppendingToAnObjectOutputStream" start="21" end="21" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="20" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 21]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="cff3b96e366dd11c97ec3fe55ef625d3" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject3(String, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/lang/String;Ljava/lang/Object;)V" name="appendObject3" primary="true">
+      <SourceLine endBytecode="62" classname="AppendingToAnObjectOutputStream" start="28" end="31" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject3(String, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="13" classname="AppendingToAnObjectOutputStream" start="28" end="28" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="13" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 28]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="9348141520cc8532ae7a66b94539b443" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject4(String, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/lang/String;Ljava/lang/Object;)V" name="appendObject4" primary="true">
+      <SourceLine endBytecode="69" classname="AppendingToAnObjectOutputStream" start="35" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject4(String, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="20" classname="AppendingToAnObjectOutputStream" start="35" end="35" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="20" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 35]</Message>
+    </SourceLine>
+  </BugInstance>
+</BugCollection>

--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BugCollection sequence="0" release="" analysisTimestamp="1653586688929" version="4.7.0" timestamp="1653586685292">
+  <BugInstance instanceOccurrenceNum="0" instanceHash="a7786a4e4e4b9291a71529139eda42d1" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject1(File, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/io/File;Ljava/lang/Object;)V" name="appendObject1" primary="true">
+      <SourceLine endBytecode="62" classname="AppendingToAnObjectOutputStream" start="14" end="17" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject1(File, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="13" classname="AppendingToAnObjectOutputStream" start="14" end="14" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="13" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 14]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="291247b70690f65de576af5f247deda2" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject2(File, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/io/File;Ljava/lang/Object;)V" name="appendObject2" primary="true">
+      <SourceLine endBytecode="69" classname="AppendingToAnObjectOutputStream" start="21" end="24" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject2(File, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="20" classname="AppendingToAnObjectOutputStream" start="21" end="21" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="20" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 21]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="cff3b96e366dd11c97ec3fe55ef625d3" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject3(String, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/lang/String;Ljava/lang/Object;)V" name="appendObject3" primary="true">
+      <SourceLine endBytecode="62" classname="AppendingToAnObjectOutputStream" start="28" end="31" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject3(String, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="13" classname="AppendingToAnObjectOutputStream" start="28" end="28" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="13" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 28]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="9348141520cc8532ae7a66b94539b443" rank="5" abbrev="IO" category="CORRECTNESS" priority="1" type="IO_APPENDING_TO_OBJECT_OUTPUT_STREAM" instanceOccurrenceMax="0">
+    <ShortMessage>Doomed attempt to append to an object output stream</ShortMessage>
+    <LongMessage>Doomed attempt to append to an object output stream in AppendingToAnObjectOutputStream.appendObject4(String, Object)</LongMessage>
+    <Class classname="AppendingToAnObjectOutputStream" primary="true">
+      <SourceLine classname="AppendingToAnObjectOutputStream" start="10" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java">
+        <Message>At AppendingToAnObjectOutputStream.java:[lines 10-38]</Message>
+      </SourceLine>
+      <Message>In class AppendingToAnObjectOutputStream</Message>
+    </Class>
+    <Method isStatic="true" classname="AppendingToAnObjectOutputStream" signature="(Ljava/lang/String;Ljava/lang/Object;)V" name="appendObject4" primary="true">
+      <SourceLine endBytecode="69" classname="AppendingToAnObjectOutputStream" start="35" end="38" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="0"/>
+      <Message>In method AppendingToAnObjectOutputStream.appendObject4(String, Object)</Message>
+    </Method>
+    <SourceLine endBytecode="20" classname="AppendingToAnObjectOutputStream" start="35" end="35" sourcepath="AppendingToAnObjectOutputStream.java" sourcefile="AppendingToAnObjectOutputStream.java" startBytecode="20" primary="true">
+      <Message>At AppendingToAnObjectOutputStream.java:[line 35]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c7f9edd192cfef80d2e55dde64a514bc" rank="2" abbrev="INT" category="CORRECTNESS" priority="1" type="INT_BAD_COMPARISON_WITH_SIGNED_BYTE" instanceOccurrenceMax="0">
+    <ShortMessage>Bad comparison of signed byte</ShortMessage>
+    <LongMessage>Bad comparison of signed byte with 200 in AssumeUnsignedBytes.find200(byte[])</LongMessage>
+    <Class classname="AssumeUnsignedBytes" primary="true">
+      <SourceLine classname="AssumeUnsignedBytes" start="3" end="10" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java">
+        <Message>At AssumeUnsignedBytes.java:[lines 3-10]</Message>
+      </SourceLine>
+      <Message>In class AssumeUnsignedBytes</Message>
+    </Class>
+    <Method isStatic="false" classname="AssumeUnsignedBytes" signature="([B)I" name="find200" primary="true">
+      <SourceLine endBytecode="82" classname="AssumeUnsignedBytes" start="7" end="10" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java" startBytecode="0"/>
+      <Message>In method AssumeUnsignedBytes.find200(byte[])</Message>
+    </Method>
+    <Int role="INT_VALUE" value="200">
+      <Message>Value 200</Message>
+    </Int>
+    <SourceLine endBytecode="14" classname="AssumeUnsignedBytes" start="8" end="8" sourcepath="AssumeUnsignedBytes.java" sourcefile="AssumeUnsignedBytes.java" startBytecode="14" primary="true">
+      <Message>At AssumeUnsignedBytes.java:[line 8]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c44f97bf502b32aba37c238aae4e404c" rank="14" abbrev="HE" category="BAD_PRACTICE" priority="1" type="HE_EQUALS_USE_HASHCODE" instanceOccurrenceMax="0">
+    <ShortMessage>Class defines equals() and uses Object.hashCode()</ShortMessage>
+    <LongMessage>UseOfNonHashableClassInHashDataStructure defines equals and uses Object.hashCode()</LongMessage>
+    <Class classname="UseOfNonHashableClassInHashDataStructure" primary="true">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure" start="3" end="24" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[lines 3-24]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure</Message>
+    </Class>
+    <Method isStatic="false" classname="UseOfNonHashableClassInHashDataStructure" signature="(Ljava/lang/Object;)Z" name="equals" primary="true">
+      <SourceLine endBytecode="51" classname="UseOfNonHashableClassInHashDataStructure" start="16" end="16" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java" startBytecode="0"/>
+      <Message>In method UseOfNonHashableClassInHashDataStructure.equals(Object)</Message>
+    </Method>
+    <SourceLine synthetic="true" endBytecode="51" classname="UseOfNonHashableClassInHashDataStructure" start="16" end="16" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java" startBytecode="0">
+      <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="a4564c101ee03f13b56ee6a6b66efd77" rank="5" abbrev="HE" category="CORRECTNESS" priority="1" type="HE_SIGNATURE_DECLARES_HASHING_OF_UNHASHABLE_CLASS" instanceOccurrenceMax="0">
+    <ShortMessage>Signature declares use of unhashable class in hashed construct</ShortMessage>
+    <LongMessage>UseOfNonHashableClassInHashDataStructure doesn't define a hashCode() method but it is used in a hashed context in UseOfNonHashableClassInHashDataStructure$UMap</LongMessage>
+    <Class classname="UseOfNonHashableClassInHashDataStructure$UMap" primary="true">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure$UMap</Message>
+    </Class>
+    <Class classname="UseOfNonHashableClassInHashDataStructure$UMap">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+      </SourceLine>
+      <Message>In class UseOfNonHashableClassInHashDataStructure$UMap</Message>
+    </Class>
+    <Type role="TYPE_UNHASHABLE" descriptor="LUseOfNonHashableClassInHashDataStructure;">
+      <SourceLine classname="UseOfNonHashableClassInHashDataStructure" start="3" end="24" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+        <Message>At UseOfNonHashableClassInHashDataStructure.java:[lines 3-24]</Message>
+      </SourceLine>
+      <Message>Unhashable class UseOfNonHashableClassInHashDataStructure </Message>
+    </Type>
+    <SourceLine synthetic="true" classname="UseOfNonHashableClassInHashDataStructure$UMap" start="5" end="5" sourcepath="UseOfNonHashableClassInHashDataStructure.java" sourcefile="UseOfNonHashableClassInHashDataStructure.java">
+      <Message>At UseOfNonHashableClassInHashDataStructure.java:[line 5]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="e248f9d4626fdfcebf961d28bcbd1d88" cweid="563" rank="5" abbrev="DLS" category="CORRECTNESS" priority="1" type="DLS_OVERWRITTEN_INCREMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Overwritten increment</ShortMessage>
+    <LongMessage>Overwritten increment in UselessAssignments.oops()</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="()I" name="oops" primary="true">
+      <SourceLine endBytecode="88" classname="UselessAssignments" start="28" end="33" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method UselessAssignments.oops()</Message>
+    </Method>
+    <SourceLine endBytecode="12" classname="UselessAssignments" start="30" end="30" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="12" primary="true">
+      <Message>At UselessAssignments.java:[line 30]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c845f2f6bcbb54ef6993e667f2ab9f6a" rank="1" abbrev="SA" category="CORRECTNESS" priority="1" type="SA_FIELD_SELF_ASSIGNMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Self assignment of field</ShortMessage>
+    <LongMessage>Self assignment of field foo in new UselessAssignments(int, int)</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="(II)V" name="&lt;init&gt;" primary="true">
+      <SourceLine endBytecode="72" classname="UselessAssignments" start="14" end="20" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method new UselessAssignments(int, int)</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <LocalVariable role="LOCAL_VARIABLE_DID_YOU_MEAN" pc="0" name="?" register="1">
+      <Message>Did you mean to refer to the local variable ?</Message>
+    </LocalVariable>
+    <SourceLine endBytecode="9" classname="UselessAssignments" start="16" end="16" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="9" primary="true">
+      <Message>At UselessAssignments.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="48138b3b7d208c1dee75d30c88c3f630" rank="1" abbrev="SA" category="CORRECTNESS" priority="1" type="SA_FIELD_SELF_ASSIGNMENT" instanceOccurrenceMax="0">
+    <ShortMessage>Self assignment of field</ShortMessage>
+    <LongMessage>Self assignment of field foo in UselessAssignments.oops()</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="()I" name="oops" primary="true">
+      <SourceLine endBytecode="88" classname="UselessAssignments" start="28" end="33" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method UselessAssignments.oops()</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <SourceLine endBytecode="25" classname="UselessAssignments" start="31" end="31" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="25" primary="true">
+      <Message>At UselessAssignments.java:[line 31]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="ef8d86e8b4ffe32c6b42c02f53d79967" rank="1" abbrev="UR" category="CORRECTNESS" priority="1" type="UR_UNINIT_READ" instanceOccurrenceMax="0">
+    <ShortMessage>Uninitialized read of field in constructor</ShortMessage>
+    <LongMessage>Uninitialized read of foo in new UselessAssignments(int, int)</LongMessage>
+    <Class classname="UselessAssignments" primary="true">
+      <SourceLine classname="UselessAssignments" start="14" end="42" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>At UselessAssignments.java:[lines 14-42]</Message>
+      </SourceLine>
+      <Message>In class UselessAssignments</Message>
+    </Class>
+    <Method isStatic="false" classname="UselessAssignments" signature="(II)V" name="&lt;init&gt;" primary="true">
+      <SourceLine endBytecode="72" classname="UselessAssignments" start="14" end="20" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="0"/>
+      <Message>In method new UselessAssignments(int, int)</Message>
+    </Method>
+    <Field isStatic="false" classname="UselessAssignments" signature="I" name="foo" primary="true">
+      <SourceLine classname="UselessAssignments" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java">
+        <Message>In UselessAssignments.java</Message>
+      </SourceLine>
+      <Message>Field UselessAssignments.foo</Message>
+    </Field>
+    <LocalVariable role="LOCAL_VARIABLE_DID_YOU_MEAN" pc="0" name="?" register="1">
+      <Message>Did you mean to refer to the local variable ?</Message>
+    </LocalVariable>
+    <SourceLine endBytecode="6" classname="UselessAssignments" start="16" end="16" sourcepath="UselessAssignments.java" sourcefile="UselessAssignments.java" startBytecode="6" primary="true">
+      <Message>At UselessAssignments.java:[line 16]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance instanceOccurrenceNum="0" instanceHash="c605add53d7d36f5dea72b09c753696b" rank="19" abbrev="Dm" category="I18N" priority="1" type="DM_DEFAULT_ENCODING" instanceOccurrenceMax="0">
+    <ShortMessage>Reliance on default encoding</ShortMessage>
+    <LongMessage>Found reliance on default encoding in UserMistakes.main(String[]): new java.io.FileReader(String)</LongMessage>
+    <Class classname="UserMistakes" primary="true">
+      <SourceLine classname="UserMistakes" start="10" end="43" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java">
+        <Message>At UserMistakes.java:[lines 10-43]</Message>
+      </SourceLine>
+      <Message>In class UserMistakes</Message>
+    </Class>
+    <Method isStatic="true" classname="UserMistakes" signature="([Ljava/lang/String;)V" name="main" primary="true">
+      <SourceLine endBytecode="318" classname="UserMistakes" start="13" end="43" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="0"/>
+      <Message>In method UserMistakes.main(String[])</Message>
+    </Method>
+    <Method isStatic="false" role="METHOD_CALLED" classname="java.io.FileReader" signature="(Ljava/lang/String;)V" name="&lt;init&gt;">
+      <SourceLine endBytecode="68" classname="java.io.FileReader" start="60" end="61" sourcepath="java/io/FileReader.java" sourcefile="FileReader.java" startBytecode="0"/>
+      <Message>Called method new java.io.FileReader(String)</Message>
+    </Method>
+    <SourceLine endBytecode="57" classname="UserMistakes" start="26" end="26" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="57" primary="true">
+      <Message>At UserMistakes.java:[line 26]</Message>
+    </SourceLine>
+    <SourceLine role="SOURCE_LINE_ANOTHER_INSTANCE" endBytecode="111" classname="UserMistakes" start="37" end="37" sourcepath="UserMistakes.java" sourcefile="UserMistakes.java" startBytecode="111">
+      <Message>Another occurrence at UserMistakes.java:[line 37]</Message>
+    </SourceLine>
+  </BugInstance>
+</BugCollection>

--- a/src/it/check-bug-file-multi-list/invoker.properties
+++ b/src/it/check-bug-file-multi-list/invoker.properties
@@ -1,0 +1,6 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success
+
+#invoker.mavenOpts = -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/src/it/check-bug-file-multi-list/pom.xml
+++ b/src/it/check-bug-file-multi-list/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check-bug-file-multi-list</artifactId>
+  <name>check-bug-file-multi-list</name>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>spotbugs-maven-plugin.it</groupId>
+        <artifactId>build-tools</artifactId>
+        <version>testing</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>true</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <threshold>High</threshold>
+          <excludeBugsFiles>
+            <excludeBugsFile>baseline/spotbugs-baseline-outputstream.xml</excludeBugsFile>
+            <excludeBugsFile>baseline/spotbugs-baseline-other.xml</excludeBugsFile>
+          </excludeBugsFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-bug-file-multi-list/verify.groovy
+++ b/src/it/check-bug-file-multi-list/verify.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+assert xdocErrors == 0
+assert spotbugsXmlErrors == 0

--- a/src/it/check-bug-file-multi/invoker.properties
+++ b/src/it/check-bug-file-multi/invoker.properties
@@ -1,0 +1,6 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success
+
+#invoker.mavenOpts = -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/src/it/check-bug-file-multi/pom.xml
+++ b/src/it/check-bug-file-multi/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check-bug-file-multi</artifactId>
+  <name>check-bug-file-multi</name>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>spotbugs-maven-plugin.it</groupId>
+        <artifactId>build-tools</artifactId>
+        <version>testing</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>true</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <threshold>High</threshold>
+          <excludeBugsFile>baseline/spotbugs-baseline-outputstream.xml,baseline/spotbugs-baseline-other.xml</excludeBugsFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-bug-file-multi/verify.groovy
+++ b/src/it/check-bug-file-multi/verify.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+assert xdocErrors == 0
+assert spotbugsXmlErrors == 0

--- a/src/it/check-bug-file/invoker.properties
+++ b/src/it/check-bug-file/invoker.properties
@@ -1,0 +1,6 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success
+
+#invoker.mavenOpts = -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/src/it/check-bug-file/pom.xml
+++ b/src/it/check-bug-file/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check-bug-file</artifactId>
+  <name>check-bug-file</name>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>spotbugs-maven-plugin.it</groupId>
+        <artifactId>build-tools</artifactId>
+        <version>testing</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>true</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <threshold>High</threshold>
+          <excludeBugsFile>baseline/spotbugs-baseline.xml</excludeBugsFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-bug-file/verify.groovy
+++ b/src/it/check-bug-file/verify.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+assert xdocErrors == 0
+assert spotbugsXmlErrors == 0

--- a/src/it/exclude-multi-list/invoker.properties
+++ b/src/it/exclude-multi-list/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/exclude-multi-list/pom.xml
+++ b/src/it/exclude-multi-list/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>excludeFile-multi-list</artifactId>
+  <name>excludeFile-multi-list</name>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>spotbugs-maven-plugin.it</groupId>
+        <artifactId>build-tools</artifactId>
+        <version>testing</version>
+      </extension>
+    </extensions>
+  </build>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxrPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <excludeFilterFiles>
+              <excludeFilterFile>whizbang/lib-filter.xml</excludeFilterFile>
+              <excludeFilterFile>filters/lib-filter2.xml</excludeFilterFile>
+          </excludeFilterFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/exclude-multi-list/verify.groovy
+++ b/src/it/exclude-multi-list/verify.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
+assert spotbugsHtml.exists()
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+
+println '***************************'
+println "Checking HTML file"
+println '***************************'
+
+def xhtmlParser = new XmlSlurper();
+xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+xhtmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+def path = xhtmlParser.parse( spotbugsHtml )
+//*[@id="contentBox"]/div[2]/table/tbody/tr[2]/td[2]
+def spotbugsErrors = path.body.'**'.find {div -> div.@id == 'contentBox'}.section[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+
+assert xdocErrors == spotbugsXmlErrors
+
+assert spotbugsErrors == spotbugsXmlErrors

--- a/src/it/include-multi-list/invoker.properties
+++ b/src/it/include-multi-list/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/include-multi-list/pom.xml
+++ b/src/it/include-multi-list/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>includeFile-multi-list</artifactId>
+  <name>includeFile-multi-list</name>
+  <packaging>jar</packaging>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>spotbugs-maven-plugin.it</groupId>
+        <artifactId>build-tools</artifactId>
+        <version>testing</version>
+      </extension>
+    </extensions>
+  </build>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxrPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <includeFilterFiles>
+              <includeFilterFile>whizbang/lib-filter.xml</includeFilterFile>
+              <includeFilterFile>filters/lib-filter2.xml</includeFilterFile>
+          </includeFilterFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/include-multi-list/verify.groovy
+++ b/src/it/include-multi-list/verify.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
+assert spotbugsHtml.exists()
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+
+println '***************************'
+println "Checking HTML file"
+println '***************************'
+
+def xhtmlParser = new XmlSlurper();
+xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+xhtmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+def path = xhtmlParser.parse( spotbugsHtml )
+//*[@id="contentBox"]/div[2]/table/tbody/tr[2]/td[2]
+def spotbugsErrors = path.body.'**'.find {div -> div.@id == 'contentBox'}.section[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+
+assert xdocErrors == spotbugsXmlErrors
+
+assert spotbugsErrors == spotbugsXmlErrors

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -284,6 +284,32 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
     /**
      * <p>
+     * File name for include filter files. Only bugs in matching the filters are reported.
+     * </p>
+     *
+     * <p>
+     * Potential values are a filesystem path, a URL, or a classpath resource.
+     * </p>
+     *
+     * <p>
+     * This is an alternative to <code>&lt;includeFilterFile&gt;</code> which allows multiple
+     * files to be specified as separate elements in a pom.
+     * </p>
+     *
+     * <p>
+     * This parameter is resolved as resource, URL, then file. If successfully
+     * resolved, the contents of the configuration is copied into the
+     * <code>${project.build.directory}</code>
+     * directory before being passed to Spotbugs as a filter file.
+     * </p>
+     *
+     * @since 4.7.0.1-SNAPSHOT
+     */
+    @Parameter(property = "spotbugs.includeFilterFiles")
+    List includeFilterFiles
+
+    /**
+     * <p>
      * File name of the exclude filter. Bugs matching the filters are not reported.
      * </p>
      *
@@ -908,6 +934,16 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             String[] includefilters = includeFilterFile.split(SpotBugsInfo.COMMA)
 
             includefilters.each { includefilter ->
+                args << "-include"
+                args << resourceHelper.getResourceFile(includefilter.trim())
+            }
+
+        }
+
+        if (includeFilterFiles) {
+            log.debug("  Adding Include Filter Files ")
+
+            includeFilterFiles.each { includefilter ->
                 args << "-include"
                 args << resourceHelper.getResourceFile(includefilter.trim())
             }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -332,6 +332,28 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
     /**
      * <p>
+     * File name for exclude filter files. Bugs matching the filters are not reported.
+     * </p>
+     *
+     * <p>
+     * This is an alternative to <code>&lt;excludeFilterFile&gt;</code> which allows multiple
+     * files to be specified as separate elements in a pom.
+     * </p>
+     *
+     * <p>
+     * This parameter is resolved as resource, URL, then file. If successfully
+     * resolved, the contents of the configuration is copied into the
+     * <code>${project.build.directory}</code>
+     * directory before being passed to Spotbugs as a filter file.
+     * </p>
+     *
+     * @since 4.7.0.1-SNAPSHOT
+     */
+    @Parameter(property = "spotbugs.excludeFilterFiles")
+    List excludeFilterFiles
+
+    /**
+     * <p>
      * File names of the baseline files. Bugs found in the baseline files won't be reported.
      * </p>
      *
@@ -955,6 +977,16 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             String[] excludefilters = excludeFilterFile.split(SpotBugsInfo.COMMA)
 
             excludefilters.each { excludeFilter ->
+                args << "-exclude"
+                args << resourceHelper.getResourceFile(excludeFilter.trim())
+            }
+
+        }
+
+        if (excludeFilterFiles) {
+            log.debug("  Adding Exclude Filter Files ")
+
+            excludeFilterFiles.each { excludeFilter ->
                 args << "-exclude"
                 args << resourceHelper.getResourceFile(excludeFilter.trim())
             }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -376,6 +376,32 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     String excludeBugsFile
 
     /**
+     * <p>
+     * File names of the baseline files. Bugs found in the baseline files won't be reported.
+     * </p>
+     *
+     * <p>
+     * Potential values are a filesystem path, a URL, or a classpath resource.
+     * </p>
+     *
+     * <p>
+     * This is an alternative to <code>&lt;excludeBugsFile&gt;</code> which allows multiple
+     * files to be specified as separate elements in a pom.
+     * </p>
+     *
+     * <p>
+     * This parameter is resolved as resource, URL, then file. If successfully
+     * resolved, the contents of the configuration is copied into the
+     * <code>${project.build.directory}</code>
+     * directory before being passed to Spotbugs as a filter file.
+     * </p>
+     *
+     * @since 4.7.0.1-SNAPSHOT
+     */
+    @Parameter(property = "spotbugs.excludeBugsFiles")
+    List excludeBugsFiles
+
+    /**
      * Effort of the bug finders. Valid values are Min, Default and Max.
      *
      * @since 1.0-beta-1
@@ -994,10 +1020,19 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         if (excludeBugsFile) {
-            log.debug("  Adding Exclude Bug Files (Baselines)")
+            log.debug("  Adding Exclude Bug File (Baselines)")
             String[] excludeFiles = excludeBugsFile.split(SpotBugsInfo.COMMA)
 
             excludeFiles.each() { excludeFile ->
+                args << "-excludeBugs"
+                args << resourceHelper.getResourceFile(excludeFile.trim())
+            }
+        }
+
+        if (excludeBugsFiles) {
+            log.debug("  Adding Exclude Bug Files (Baselines)")
+
+            excludeBugsFiles.each() { excludeFile ->
                 args << "-excludeBugs"
                 args << resourceHelper.getResourceFile(excludeFile.trim())
             }


### PR DESCRIPTION
The spotbugs plugin only supports multiple files for bug inclusion, exclusion and baseline definition as comma-separated values in the single properties. This makes it very hard to use multiple sets of files in multi-module projects. One basically ends up with overriding the value in every module.

This patch adds additional list support for `<includeFilterFile>`, `<excludeFilterFile>` and `<excludeBugsFile>` as

```
<includeFilterFiles>
  <includeFilterFile>...</includeFilterFile>
  <includeFilterFile>...</includeFilterFile>
</includeFilterFiles>

<excludeFilterFiles>
  <excludeFilterFile>...</excludeFilterFile>
  <excludeFilterFile>...</excludeFilterFile>
</excludeFilterFiles>

<excludeBugsFiles>
  <excludeBugsFile>...</excludeBugsFile>
  <excludeBugsFile>...</excludeBugsFile>
</excludeBugsFiles>
```

This allows the use of the maven `combine.children` setting to dynamically control the set of files for each subproject, e.g.

Main project:

```
[parent pom]
<excludeFilterFiles>
  <excludeFilterFile>globalFilterFile.xml</excludeFilterFiles>
<excludeFilterFiles>
```

Sub module A:

```
[inherits from parent pom]
<excludeFilterFiles combine.children="append">
  <excludeFilterFile>moduleAFilterFile.xml</excludeFilterFiles>
<excludeFilterFiles>
```

Sub module B:

```
[inherits from parent pom]
<excludeFilterFiles combine.children="append">
  <excludeFilterFile>moduleBFilterFile.xml</excludeFilterFiles>
<excludeFilterFiles>
```

Thus having the `globalFilterFile.xml` and `moduleAFilterFile.xml` applied to Sub module A and `globalFilterFile.xml` and `moduleBFilterFile.xml` applied to Sub module B.

For large projects, this dramatically simplifies configuring spotbugs.

This PR contains integration tests for all the changes (and some for the filter bugs that should have been there. :-) ) 



