### PR TITLE
Build updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: "maven"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,12 @@
       <artifactId>groovy-xml</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-core</artifactId>
+      <version>${javaparserVersion}</version>
+    </dependency>
+
     <!-- Maven -->
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
@@ -559,11 +565,6 @@
               <groupId>org.apache.maven.doxia</groupId>
               <artifactId>doxia-sink-api</artifactId>
               <version>${doxiaVersion}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.github.javaparser</groupId>
-              <artifactId>javaparser-core</artifactId>
-              <version>${javaparserVersion}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
For site, groovy 4.0.3 changed from 4.0.2 in that javaparser no longer works how it was setup here.  Moved it so site works again.

For dependabot, add in github actions too.