### PR TITLE
Validate Spotbugs report even if only test sources exist

### DIFF
--- a/src/it/check-bug-only-test-sources/invoker.properties
+++ b/src/it/check-bug-only-test-sources/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean package spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = failure

--- a/src/it/check-bug-only-test-sources/pom.xml
+++ b/src/it/check-bug-only-test-sources/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check-bug-only-test-sources</artifactId>
+  <name>check-bug-only-test-sources</name>
+  <packaging>jar</packaging>
+
+  <build>
+    <sourceDirectory>src/main</sourceDirectory><!-- empty main source directory -->
+    <testSourceDirectory>@project.basedir@/src/it-src/test/java</testSourceDirectory>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <failOnError>true</failOnError>
+          <includeTests>true</includeTests>
+          <debug>@spotbugsTestDebug@</debug>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-bug-only-test-sources/verify.groovy
+++ b/src/it/check-bug-only-test-sources/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( 'BugInstance size is 2' )

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/BaseViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/BaseViolationCheckMojo.groovy
@@ -479,15 +479,10 @@ abstract class BaseViolationCheckMojo extends AbstractMojo {
     @Override
     void execute() {
         Locale locale = Locale.getDefault()
-        List sourceFiles
 
         log.debug("Executing spotbugs:check")
 
-        if (this.classFilesDirectory.exists() && this.classFilesDirectory.isDirectory()) {
-            sourceFiles = FileUtils.getFiles(classFilesDirectory, SpotBugsInfo.JAVA_REGEX_PATTERN, null)
-        }
-
-        if (!skip && sourceFiles) {
+        if (!skip && doSourceFilesExist()) {
 
             // this goes
 
@@ -553,6 +548,20 @@ abstract class BaseViolationCheckMojo extends AbstractMojo {
         else {
             log.debug("Nothing for SpotBugs to do here.")
         }
+    }
+
+    private boolean doSourceFilesExist() {
+        List sourceFiles = new ArrayList()
+
+        if (this.classFilesDirectory.exists() && this.classFilesDirectory.isDirectory()) {
+            sourceFiles.addAll(FileUtils.getFiles(classFilesDirectory, SpotBugsInfo.JAVA_REGEX_PATTERN, null))
+        }
+
+        if (this.includeTests && this.testClassFilesDirectory.exists() && this.testClassFilesDirectory.isDirectory()) {
+            sourceFiles.addAll(FileUtils.getFiles(testClassFilesDirectory, SpotBugsInfo.JAVA_REGEX_PATTERN, null))
+        }
+
+        !sourceFiles.isEmpty()
     }
 
     private void printBugs(total, bugs) {


### PR DESCRIPTION
If you use this plugin in a project that only has test sources (source
files in the folder `src/test/`) and no source files in the main folder
(`src/main/`), then it'd not validate the report generated by spotbugs.
Instead it would only log 0 bugs.

Instead of verifying only the folder for class files (main folder), we
also check if there are test class files (only if the option
`includeTests` is enabled). If there are test files, validation of the
report takes place.

Fixes #454