### PR TITLE
[pom] Move to codehaus l10n-maven-plugin 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <plexusUtilsVersion>3.4.2</plexusUtilsVersion>
 
     <antrunPluginVersion>3.1.0</antrunPluginVersion>
-    <l10nPluginVersion>1.8</l10nPluginVersion>
+    <l10nPluginVersion>1.0.0</l10nPluginVersion>
     <codenarcPluginVersion>0.22-1</codenarcPluginVersion>
     <gmavenPluginVersion>1.13.1</gmavenPluginVersion>
     <infoReportsPluginVersion>3.4.0</infoReportsPluginVersion>
@@ -698,7 +698,7 @@
         <version>${infoReportsPluginVersion}</version>
       </plugin>
       <plugin>
-        <groupId>com.googlecode.l10n-maven-plugin</groupId>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>l10n-maven-plugin</artifactId>
         <version>${l10nPluginVersion}</version>
         <configuration>


### PR DESCRIPTION
other one is not supported any longer and was from 2014.  This one was way out of date too but is back to support and released in 2022.

The current used one is broken but this one is working.