### PR TITLE
[pom] Cleanup spotbugs on site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -700,14 +700,6 @@
     <excludeDefaults>true</excludeDefaults>
     <plugins>
       <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${project.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${javadocPluginVersion}</version>
@@ -751,8 +743,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>${project.artifactId}</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${project.version}</version>
       </plugin>
       <plugin>


### PR DESCRIPTION
likely was when parent was still using the fork originally, had it listed two times.  Clarify second by using actual group and artifact like everything else in this, keep project version.  Remove the other one as it was running anyways.