### PR TITLE
Reproducible Builds: override timestamp value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,9 @@
 
     <projectVersion>${project.version}</projectVersion>
 
+    <!-- Reproducible Builds: override timestamp value from parent -->
+    <project.build.outputTimestamp>1657151022</project.build.outputTimestamp>
+
     <!-- Override spotbugs to this version from base-parent -->
     <spotbugs.version>4.7.2</spotbugs.version>
 


### PR DESCRIPTION
this will bring a timestamp in jar files that are more natural because matching the current project's release

notice: even with timestamp value inherited from parent, reproducible builds is ok https://github.com/jvm-repo-rebuild/reproducible-central/tree/master/content/com/github/spotbugs