### PR TITLE
#549 Pass the auxiliary classpath using the -auxclasspathFromFile agument

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -870,6 +870,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     private ArrayList<String> getSpotbugsArgs(File htmlTempFile, File xmlTempFile, File sarifTempFile) {
         ResourceHelper resourceHelper = new ResourceHelper(log, spotbugsXmlOutputDirectory, resourceManager)
         def args = new ArrayList<String>()
+        def auxClasspathFile = createSpotbugsAuxClasspathFile()
 
         if (userPrefs) {
             log.debug(" Adding User Preferences File -> ${userPrefs}" )
@@ -886,6 +887,11 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         if (sarifOutput) {
             args << "-sarif=" + sarifTempFile.getAbsolutePath()
+        }
+
+        if (auxClasspathFile) {
+            args << "-auxclasspathFromFile"
+            args << auxClasspathFile.getAbsolutePath()
         }
 
         args << "-projectName"
@@ -1022,42 +1028,37 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     }
 
     /**
-     * Get the Spotbugs AuxClasspath.
+     * Create the Spotbugs AuxClasspath file.
      *
      */
-    private String getSpotbugsAuxClasspath() {
+    private File createSpotbugsAuxClasspathFile() {
         def auxClasspathElements
-
-        if (classFilesDirectory.exists() && classFilesDirectory.isDirectory()) {
-            auxClasspathElements = project.compileClasspathElements
-        }
 
         if (testClassFilesDirectory.exists() && testClassFilesDirectory.isDirectory() && includeTests) {
             auxClasspathElements = project.testClasspathElements
+        } else if (classFilesDirectory.exists() && classFilesDirectory.isDirectory()) {
+            auxClasspathElements = project.compileClasspathElements
         }
 
-        def auxClasspath = ""
+        File auxClasspathFile = null
 
         if (auxClasspathElements) {
+            auxClasspathFile = File.createTempFile("auxclasspath", ".tmp")
+            auxClasspathFile.deleteOnExit()
             log.debug("  AuxClasspath Elements ->" + auxClasspathElements)
 
             def auxClasspathList = auxClasspathElements.findAll { project.build.outputDirectory != it.toString() }
             if (auxClasspathList.size() > 0) {
-
-                auxClasspath += File.pathSeparator
-
                 log.debug("  Last AuxClasspath is ->" + auxClasspathList[auxClasspathList.size() - 1])
 
                 auxClasspathList.each() { auxClasspathElement ->
                     log.debug("  Adding to AuxClasspath ->" + auxClasspathElement.toString())
-                    auxClasspath += auxClasspathElement.toString() +  File.pathSeparator
+                    auxClasspathFile << auxClasspathElement.toString() + "\n"
                 }
             }
         }
 
-        log.debug("  AuxClasspath is ->" + auxClasspath)
-
-        return auxClasspath
+        return auxClasspathFile
     }
 
     /**
@@ -1142,7 +1143,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             effectiveEncoding = sourceEncoding
         }
 
-        ant.java(classname: "edu.umd.cs.findbugs.FindBugs2", inputstring: getSpotbugsAuxClasspath(), fork: "${fork}", failonerror: "true", clonevm: "false", timeout: "${timeout}", maxmemory: "${maxHeap}m") {
+        ant.java(classname: "edu.umd.cs.findbugs.FindBugs2", fork: "${fork}", failonerror: "true", clonevm: "false", timeout: "${timeout}", maxmemory: "${maxHeap}m") {
 
             log.debug("File Encoding is " + effectiveEncoding)
 


### PR DESCRIPTION
The plugin versions before 4.7.3.1 passed the auxiliary classpath via the standard input, which caused a deadlock during parallel builds with non-forked spotbugs. #488

Although this was fixed by removing the -auxclasspathFromInput, this broke the classpath logic.

The solution is to pass the classpath using a file.