### PR TITLE
[tests] Add integration test to check file open issues per #517

### DIFF
--- a/src/it/verify-clean/invoker.properties
+++ b/src/it/verify-clean/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean verify package clean
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/verify-clean/pom.xml
+++ b/src/it/verify-clean/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>check</artifactId>
+  <name>check</name>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>false</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <threshold>High</threshold>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-analysis</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>spotbugs</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>process-results</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Test simply runs through clean at end to ensure files not still open.  Using 4.7.3.0, I can repeat the reported issue.  The issue is gone in 4.7.3.1 and likely related to the auxpath issue.