### PR TITLE
[tests] Add check that we are not missing classes for analysis

### DIFF
--- a/src/it/check-no-missing-classes/invoker.properties
+++ b/src/it/check-no-missing-classes/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean compile spotbugs:check
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/check-no-missing-classes/pom.xml
+++ b/src/it/check-no-missing-classes/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2006-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <!-- Parent is disabled on purpose
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  -->
+  <groupId>spotbugs-maven-plugin.it</groupId>
+  <artifactId>check-no-missing-classes</artifactId>
+  <version>testing</version>
+  <name>check-no-missing-classes</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>@junitVersion@</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>false</failOnError>
+          <debug>@spotbugsTestDebug@</debug>
+          <threshold>High</threshold>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-analysis</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>spotbugs</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>process-results</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-no-missing-classes/pom.xml
+++ b/src/it/check-no-missing-classes/pom.xml
@@ -30,6 +30,10 @@
   <version>testing</version>
   <name>check-no-missing-classes</name>
   <packaging>jar</packaging>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/it/check-no-missing-classes/src/main/java/test/App.java
+++ b/src/it/check-no-missing-classes/src/main/java/test/App.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Hello world!
+ */
+public class App {
+
+    public static void main( String[] args ) {
+        Assertions.assertNull(args);
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/check-no-missing-classes/verify.groovy
+++ b/src/it/check-no-missing-classes/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2006-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Check no missing classes
+
+File buildLog = new File( basedir, 'build.log' )
+assert !buildLog.text.contains( 'The following classes needed for analysis were missing' ) 
+


### PR DESCRIPTION
Test ensures issue with aux path fix in 4.7.3.1 does not resurface.  Confirmed this test will fail with usage of 4.7.3.1 but is fixed now on latest.