### PR TITLE
Drop maven 4 to alpha 4 / Exclude plexus container default

### DIFF
--- a/.github/workflows/it-maven-4.0.0.yaml
+++ b/.github/workflows/it-maven-4.0.0.yaml
@@ -1,11 +1,11 @@
-name: Java Integration Tests Maven 4.0.0-alpha-5
+name: Java Integration Tests Maven 4.0.0-alpha-4
 
 on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Integration Tests Maven 4.0.0-alpha-5
+    name: Integration Tests Maven 4.0.0-alpha-4
 
     steps:
       - uses: actions/checkout@v3
@@ -14,9 +14,9 @@ jobs:
         with:
           java-version: 17
           distribution: zulu
-      - name: Load Maven 4.0.0-alpha-5
-        run: ./mvnw -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -Dmaven=4.0.0-alpha-5 --no-transfer-progress
+      - name: Load Maven 4.0.0-alpha-4
+        run: ./mvnw -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -Dmaven=4.0.0-alpha-4 --no-transfer-progress
       - name: Build Setup
-        run: ./mvnw -B -V clean install -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-5 --no-transfer-progress
+        run: ./mvnw -B -V clean install -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-4 --no-transfer-progress
       - name: Integration Test with Maven
-        run: ./mvnw -B -V -DtestSrc=remote -Prun-its clean install -Dinvoker.parallelThreads=4 -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-5 --no-transfer-progress
+        run: ./mvnw -B -V -DtestSrc=remote -Prun-its clean install -Dinvoker.parallelThreads=4 -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-4 --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -525,6 +529,12 @@
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-integration-tools</artifactId>
       <version>${doxiaSiteToolsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Commons -->
@@ -582,17 +592,6 @@
     </dependency>
 
     <!-- plexus -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
-      <version>${plexusContainerVersion}</version>
-      <exclusions>
-          <exclusion>
-              <groupId>junit</groupId>
-              <artifactId>junit</artifactId>
-          </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-resources</artifactId>


### PR DESCRIPTION
In regards to maven 4

- Alpha 5 seems to have regression that was resolve here https://github.com/apache/maven/pull/940

In regards to plexus container default

- Per #589, usage was reported.  This comes from doxia logging api.  After looking, it does not appear doxia logging api directly uses it at all.  Further all I could find on doxia 1 was usage in unit tests.  Its deleted from doxia 2.  So this does to some degree indicate we possibly make more items provided.  But for now, simply removed it out.