### PR TITLE
Add support to load onlyAnalyze classes/packages from specified file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,7 @@
                 <header>LICENSE_HEADER</header>
                 <excludes>
                   <exclude>**/*edu.umd.cs.findbugs.core.prefs</exclude>
+                  <exclude>**/*.txt</exclude>
                 </excludes>
               </licenseSet>
             </licenseSets>

--- a/src/it/onlyAnalyzeFileSource/invoker.properties
+++ b/src/it/onlyAnalyzeFileSource/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2005-2023 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean compile site
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/onlyAnalyzeFileSource/only-analyze.txt
+++ b/src/it/onlyAnalyzeFileSource/only-analyze.txt
@@ -1,0 +1,1 @@
+BC_Unconfirmed_Cast

--- a/src/it/onlyAnalyzeFileSource/pom.xml
+++ b/src/it/onlyAnalyzeFileSource/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2023 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  <artifactId>onlyAnalyzeFileSource</artifactId>
+  <name>onlyAnalyzeFileSource</name>
+  <packaging>jar</packaging>
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxrPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <spotbugsXmlOutput>true</spotbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <onlyAnalyze>file:only-analyze.txt</onlyAnalyze>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/onlyAnalyzeFileSource/verify.groovy
+++ b/src/it/onlyAnalyzeFileSource/verify.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2005-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import groovy.xml.XmlSlurper
+
+def effortLevel = 'default'
+
+File spotbugsHtml =  new File(basedir, 'target/site/spotbugs.html')
+assert spotbugsHtml.exists()
+
+File spotbugXdoc = new File(basedir, 'target/spotbugs.xml')
+assert spotbugXdoc.exists()
+
+File spotbugXml = new File(basedir, 'target/spotbugsXml.xml')
+assert spotbugXml.exists()
+
+
+println '***************************'
+println "Checking HTML file"
+println '***************************'
+
+assert spotbugsHtml.text.contains( "<i>" + effortLevel + "</i>" )
+
+def xhtmlParser = new XmlSlurper();
+xhtmlParser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+xhtmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+def path = xhtmlParser.parse( spotbugsHtml )
+//*[@id="contentBox"]/div[2]/table/tbody/tr[2]/td[2]
+def spotbugsErrors = path.body.'**'.find {div -> div.@id == 'contentBox'}.section[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+
+println '**********************************'
+println "Checking Spotbugs Native XML file"
+println '**********************************'
+
+path = new XmlSlurper().parse(spotbugXml)
+
+allNodes = path.depthFirst().collect{ it }
+def spotbugsXmlErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+
+println '***************************'
+println "Checking xDoc file"
+println '***************************'
+
+path = new XmlSlurper().parse(spotbugXdoc)
+
+allNodes = path.depthFirst().collect{ it }
+def xdocErrors = allNodes.findAll {it.name() == 'BugInstance'}.size()
+println "BugInstance size is ${xdocErrors}"
+
+
+assert xdocErrors == spotbugsXmlErrors
+
+assert spotbugsErrors == spotbugsXmlErrors

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -38,6 +38,10 @@ import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver
 import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.resource.loader.FileResourceLoader
 
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.stream.Collectors
+
 /**
  * Generates a SpotBugs Report when the site plugin is run.
  * The HTML report is generated for site commands only.
@@ -929,7 +933,9 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         if (onlyAnalyze) {
             args << "-onlyAnalyze"
-            args << onlyAnalyze
+            args << Arrays.stream(onlyAnalyze.split(",")).map {
+                it.startsWith("file:") ? Files.lines(Paths.get(it.substring(5))).collect(Collectors.joining(",")) : it
+            }.collect(Collectors.joining(","))
         }
 
         if (includeFilterFile) {


### PR DESCRIPTION
## Use Case
### When adding spotbugs to a large project, no every file can be fixed at once. In the gradual process of fixing all files, _onlyAnalyze_ is a good tool to include selected files at very beginning of analysis.
### Current implementation of parsing _onlyAnalyze_ can't read classes/packages from file.
### Having all classes/packages in pom.xml introduces a lot of boiler plate into pom file.
### So it makes sense to have _onlyAnalyze_ support for reading classes/packages from file(s).

## Changes
### Add support to load onlyAnalyze classes/packages from specified file. 
### Excluded txt files for licensing.