### PR TITLE
Fix support for loading onlyAnalyze classes/packages from specified file to handle maven modules correctly by using resourceHelper.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -934,7 +934,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         if (onlyAnalyze) {
             args << "-onlyAnalyze"
             args << Arrays.stream(onlyAnalyze.split(",")).map {
-                it.startsWith("file:") ? Files.lines(Paths.get(it.substring(5))).collect(Collectors.joining(",")) : it
+                it.startsWith("file:") ? Files.lines(resourceHelper.getResourceFile(it.substring(5)).toPath()).collect(Collectors.joining(",")) : it
             }.collect(Collectors.joining(","))
         }
 


### PR DESCRIPTION
## Use Case
Current implementation simply reads the file using given path. This may cause file not found issue for multi module maven projects.
 
## Changes
Get file path using resourceHelper before reading content.