### PR TITLE
Added support for SpotBugs' noClassOk option

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -65,6 +65,14 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     boolean xmlOutput
 
     /**
+     * Output empty warning file if no classes are specified.
+     *
+     * @since 4.8.3.0
+     */
+    @Parameter(defaultValue = "false", property = "spotbugs.noClassOk", required = true)
+    boolean noClassOk
+
+    /**
      * Turn on and off HTML output of the Spotbugs report.
      *
      * @since 4.7.3.1
@@ -1024,6 +1032,10 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         if (testClassFilesDirectory.exists() && testClassFilesDirectory.isDirectory() && includeTests) {
             log.debug("  Adding to Source Directory ->" + testClassFilesDirectory.absolutePath)
             args << testClassFilesDirectory.absolutePath
+        }
+
+        if (noClassOk) {
+            args << "-noClassOk"
         }
 
         return args


### PR DESCRIPTION
Following the discussion in https://github.com/spotbugs/spotbugs/issues/1361 it looks like it could be useful for the maven plugin to expose the `noClassOk` option, so the analysis only shows a warning message (instead of a hard fail) when it expects compiled `.class` files in a folder but cannot find any.

I tried reproducing the problem and also adding an integration test demonstrating the case where the option would be useful but could not reproduce.
@hazendaz is this change acceptable without a corresponding integrationt test?