### PR TITLE
[GHA] Bump maven 4 to alpha 10

### DIFF
--- a/.github/workflows/it-maven-4.0.0.yaml
+++ b/.github/workflows/it-maven-4.0.0.yaml
@@ -1,11 +1,11 @@
-name: Java Integration Tests Maven 4.0.0-alpha-8
+name: Java Integration Tests Maven 4.0.0-alpha-10
 
 on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Integration Tests Maven 4.0.0-alpha-8
+    name: Integration Tests Maven 4.0.0-alpha-10
 
     steps:
       - uses: actions/checkout@v4
@@ -14,9 +14,9 @@ jobs:
         with:
           java-version: 21
           distribution: zulu
-      - name: Load Maven 4.0.0-alpha-8
-        run: mvn -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -Dmaven=4.0.0-alpha-8 --no-transfer-progress
+      - name: Load Maven 4.0.0-alpha-10
+        run: mvn -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -Dmaven=4.0.0-alpha-10 --no-transfer-progress
       - name: Build Setup
-        run: ./mvnw -B -V clean install -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-8 --no-transfer-progress
+        run: ./mvnw -B -V clean install -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-10 --no-transfer-progress
       - name: Integration Test with Maven
-        run: ./mvnw -B -V -DtestSrc=remote -Prun-its clean install -Dinvoker.parallelThreads=4 -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-8 --no-transfer-progress
+        run: ./mvnw -B -V -DtestSrc=remote -Prun-its clean install -Dinvoker.parallelThreads=4 -Dlicense.skip=true -Dmaven.min-version=4.0.0-alpha-10 --no-transfer-progress


### PR DESCRIPTION
Skipped 9 as broken and locked up on github, never tested locally but maven released alpha 10 very quickly after so I suspect that was why.  This one works again.