### PR TITLE
[cleanup] Do not check both isEmpty and isDirectory as the second alr…

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/BaseViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/BaseViolationCheckMojo.groovy
@@ -505,11 +505,11 @@ abstract class BaseViolationCheckMojo extends AbstractMojo {
     private boolean doSourceFilesExist() {
         List sourceFiles = new ArrayList()
 
-        if (this.classFilesDirectory.exists() && this.classFilesDirectory.isDirectory()) {
+        if (this.classFilesDirectory.isDirectory()) {
             sourceFiles.addAll(FileUtils.getFiles(classFilesDirectory, SpotBugsInfo.JAVA_REGEX_PATTERN, null))
         }
 
-        if (this.includeTests && this.testClassFilesDirectory.exists() && this.testClassFilesDirectory.isDirectory()) {
+        if (this.includeTests && this.testClassFilesDirectory.isDirectory()) {
             sourceFiles.addAll(FileUtils.getFiles(testClassFilesDirectory, SpotBugsInfo.JAVA_REGEX_PATTERN, null))
         }
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1016,12 +1016,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             args << maxRank
         }
 
-        if (classFilesDirectory.exists() && classFilesDirectory.isDirectory()) {
+        if (classFilesDirectory.isDirectory()) {
             log.debug("  Adding to Source Directory ->" + classFilesDirectory.absolutePath)
             args << classFilesDirectory.absolutePath
         }
 
-        if (testClassFilesDirectory.exists() && testClassFilesDirectory.isDirectory() && includeTests) {
+        if (testClassFilesDirectory.isDirectory() && includeTests) {
             log.debug("  Adding to Source Directory ->" + testClassFilesDirectory.absolutePath)
             args << testClassFilesDirectory.absolutePath
         }
@@ -1041,9 +1041,9 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     private File createSpotbugsAuxClasspathFile() {
         List<String> auxClasspathElements
 
-        if (testClassFilesDirectory.exists() && testClassFilesDirectory.isDirectory() && includeTests) {
+        if (testClassFilesDirectory.isDirectory() && includeTests) {
             auxClasspathElements = project.testClasspathElements
-        } else if (classFilesDirectory.exists() && classFilesDirectory.isDirectory()) {
+        } else if (classFilesDirectory.isDirectory()) {
             auxClasspathElements = project.compileClasspathElements
         }
 
@@ -1221,7 +1221,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                     xmlProject.appendNode { SrcDir(compileSourceRoot) }
                 }
 
-                if (testClassFilesDirectory.exists() && testClassFilesDirectory.isDirectory() && includeTests) {
+                if (testClassFilesDirectory.isDirectory() && includeTests) {
                     testSourceRoots.each() { testSourceRoot ->
                         xmlProject.appendNode { SrcDir(testSourceRoot) }
                     }


### PR DESCRIPTION
…eady checks the first