### PR TITLE
fix outputDirectory not work at running spotbugs:spotbugs goal

### DIFF
--- a/src/it/html-report/pom.xml
+++ b/src/it/html-report/pom.xml
@@ -37,6 +37,7 @@
         <configuration>
           <xmlOutput>true</xmlOutput>
           <htmlOutput>true</htmlOutput>
+          <outputDirectory>target/test-output-directory</outputDirectory>
           <failOnError>false</failOnError>
           <debug>@spotbugsTestDebug@</debug>
           <threshold>High</threshold>

--- a/src/it/html-report/verify.groovy
+++ b/src/it/html-report/verify.groovy
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-File spotbugsHtml =  new File(basedir, 'target/spotbugs.html')
+File spotbugsHtml =  new File(basedir, 'target/test-output-directory/spotbugs.html')
 assert spotbugsHtml.exists()

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1098,7 +1098,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         log.debug("****** SpotBugsMojo executeSpotbugs *******")
 
-        File htmlTempFile = new File("${project.build.directory}/spotbugs.html")
+        File htmlTempFile = new File("${outputDirectory}/spotbugs.html")
         if (htmlOutput) {
             forceFileCreation(htmlTempFile)
         }


### PR DESCRIPTION
[outputDirectory](https://spotbugs.github.io/spotbugs-maven-plugin/spotbugs-mojo.html#outputDirectory) is not working pretty well when I try to run `mvn spotbugs:spotbugs` command.
I think maybe the htmlTempFile should be use `outputDirectory`.
Can you take a look of my PR, Thank you.