### PR TITLE
Remove scripts as deprecated and not known to be used.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SourceFileIndexer.groovy
@@ -58,10 +58,6 @@ class SourceFileIndexer {
             scanDirectory(new File(sourceRoot), allSourceFiles, basePath)
         }
 
-        for (String sourceRoot in session.getCurrentProject().getScriptSourceRoots()) {
-            scanDirectory(new File(sourceRoot), allSourceFiles, basePath)
-        }
-
         //While not perfect, add the following paths will add basic support for Kotlin and Groovy
         scanDirectory(new File(session.getCurrentProject().getBasedir(),"src/main/webapp"), allSourceFiles, basePath)
         scanDirectory(new File(session.getCurrentProject().getBasedir(),"src/main/groovy"), allSourceFiles, basePath)


### PR DESCRIPTION
maven has this deprecated, I've never personally used it, never seen it documented and can only assume it was meant to split scripts out which spotbugs would not look at anyways since those are not compiled class files.  Therefore just deleting it.