### PR TITLE
[ci] Update all copyrights on all files to 2025

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/format.xml
+++ b/format.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-src/test/java/org/codehaus/mojo/spotbugsmavenplugin/it/FooTest.java
+++ b/src/it-src/test/java/org/codehaus/mojo/spotbugsmavenplugin/it/FooTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/invoker.properties
+++ b/src/it-tools/build-tools/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-other.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-other.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-outputstream.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline-outputstream.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline.xml
+++ b/src/it-tools/build-tools/src/main/resources/baseline/spotbugs-baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/src/main/resources/filters/lib-filter2.xml
+++ b/src/it-tools/build-tools/src/main/resources/filters/lib-filter2.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/src/main/resources/whizbang/lib-filter.xml
+++ b/src/it-tools/build-tools/src/main/resources/whizbang/lib-filter.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/build-tools/verify.groovy
+++ b/src/it-tools/build-tools/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it-tools/prime/invoker.properties
+++ b/src/it-tools/prime/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/it-tools/prime/src/main/resources/filters/lib-filter2.xml
+++ b/src/it-tools/prime/src/main/resources/filters/lib-filter2.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/prime/src/main/resources/whizbang/lib-filter.xml
+++ b/src/it-tools/prime/src/main/resources/whizbang/lib-filter.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it-tools/prime/verify.groovy
+++ b/src/it-tools/prime/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/MFINDBUGS-178/verify.groovy
+++ b/src/it/MFINDBUGS-178/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/basic-1/verify.groovy
+++ b/src/it/basic-1/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/change-xml-filename/pom.xml
+++ b/src/it/change-xml-filename/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/change-xml-filename/verify.groovy
+++ b/src/it/change-xml-filename/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file-multi-list/pom.xml
+++ b/src/it/check-bug-file-multi-list/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file-multi-list/verify.groovy
+++ b/src/it/check-bug-file-multi-list/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file-multi/pom.xml
+++ b/src/it/check-bug-file-multi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file-multi/verify.groovy
+++ b/src/it/check-bug-file-multi/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file/pom.xml
+++ b/src/it/check-bug-file/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-bug-file/verify.groovy
+++ b/src/it/check-bug-file/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-bug-only-test-sources/pom.xml
+++ b/src/it/check-bug-only-test-sources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-bug-only-test-sources/verify.groovy
+++ b/src/it/check-bug-only-test-sources/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-fail/pom.xml
+++ b/src/it/check-fail/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-fail/verify.groovy
+++ b/src/it/check-fail/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-failThreshold/pom.xml
+++ b/src/it/check-failThreshold/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-failThreshold/verify.groovy
+++ b/src/it/check-failThreshold/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-jvmargs/pom.xml
+++ b/src/it/check-jvmargs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-jvmargs/verify.groovy
+++ b/src/it/check-jvmargs/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-multi-filter-dups/module1/pom.xml
+++ b/src/it/check-multi-filter-dups/module1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi-filter-dups/module2/pom.xml
+++ b/src/it/check-multi-filter-dups/module2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi-filter-dups/pom.xml
+++ b/src/it/check-multi-filter-dups/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi-filter-dups/src/main/config/spotbugs-exclude-filters.xml
+++ b/src/it/check-multi-filter-dups/src/main/config/spotbugs-exclude-filters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi-filter-dups/verify.groovy
+++ b/src/it/check-multi-filter-dups/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-multi/modules/module-1/pom.xml
+++ b/src/it/check-multi/modules/module-1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi/modules/module-2/pom.xml
+++ b/src/it/check-multi/modules/module-2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi/pom.xml
+++ b/src/it/check-multi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-multi/verify.groovy
+++ b/src/it/check-multi/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-no-missing-classes/verify.groovy
+++ b/src/it/check-no-missing-classes/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-nofail/pom.xml
+++ b/src/it/check-nofail/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-nofail/verify.groovy
+++ b/src/it/check-nofail/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-pluginList-repo/verify.groovy
+++ b/src/it/check-pluginList-repo/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-skip/pom.xml
+++ b/src/it/check-skip/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-skip/verify.groovy
+++ b/src/it/check-skip/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check-timeout/pom.xml
+++ b/src/it/check-timeout/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check-timeout/verify.groovy
+++ b/src/it/check-timeout/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/check/pom.xml
+++ b/src/it/check/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/check/verify.groovy
+++ b/src/it/check/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/effort-default/pom.xml
+++ b/src/it/effort-default/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/effort-default/verify.groovy
+++ b/src/it/effort-default/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/effort-max/pom.xml
+++ b/src/it/effort-max/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/effort-max/verify.groovy
+++ b/src/it/effort-max/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/effort-min/pom.xml
+++ b/src/it/effort-min/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/effort-min/verify.groovy
+++ b/src/it/effort-min/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/empty/src/main/resources/app.properties
+++ b/src/it/empty/src/main/resources/app.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/it/empty/verify.groovy
+++ b/src/it/empty/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/encoding-utf8/verify.groovy
+++ b/src/it/encoding-utf8/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/module1/pom.xml
+++ b/src/it/exclude-modules/module1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/module1/src/main/excludeBugs.xml
+++ b/src/it/exclude-modules/module1/src/main/excludeBugs.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/module2/pom.xml
+++ b/src/it/exclude-modules/module2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/module2/src/main/excludeBugs.xml
+++ b/src/it/exclude-modules/module2/src/main/excludeBugs.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/pom.xml
+++ b/src/it/exclude-modules/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/exclude-modules/verify.groovy
+++ b/src/it/exclude-modules/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/exclude-multi-list/verify.groovy
+++ b/src/it/exclude-multi-list/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/exclude-multi/verify.groovy
+++ b/src/it/exclude-multi/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/exclude/verify.groovy
+++ b/src/it/exclude/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/excludeBugsFile/excludeBugs1.xml
+++ b/src/it/excludeBugsFile/excludeBugs1.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/excludeBugsFile/excludeBugs2.xml
+++ b/src/it/excludeBugsFile/excludeBugs2.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/excludeBugsFile/pom.xml
+++ b/src/it/excludeBugsFile/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/excludeBugsFile/verify.groovy
+++ b/src/it/excludeBugsFile/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/experimental/pom.xml
+++ b/src/it/experimental/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/experimental/verify.groovy
+++ b/src/it/experimental/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/html-report/pom.xml
+++ b/src/it/html-report/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/html-report/verify.groovy
+++ b/src/it/html-report/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/include-multi-list/verify.groovy
+++ b/src/it/include-multi-list/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/include-multi/verify.groovy
+++ b/src/it/include-multi/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/include/verify.groovy
+++ b/src/it/include/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/maxRank/pom.xml
+++ b/src/it/maxRank/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/maxRank/verify.groovy
+++ b/src/it/maxRank/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/multi-build/modules/module-1/pom.xml
+++ b/src/it/multi-build/modules/module-1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi-build/modules/module-2/pom.xml
+++ b/src/it/multi-build/modules/module-2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi-build/modules/pom.xml
+++ b/src/it/multi-build/modules/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi-build/verify.groovy
+++ b/src/it/multi-build/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/multi/modules/module-1/pom.xml
+++ b/src/it/multi/modules/module-1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi/modules/module-1/src/site/xdoc/index.xml
+++ b/src/it/multi/modules/module-1/src/site/xdoc/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi/modules/module-2/pom.xml
+++ b/src/it/multi/modules/module-2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi/modules/module-2/src/site/xdoc/index.xml
+++ b/src/it/multi/modules/module-2/src/site/xdoc/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi/pom.xml
+++ b/src/it/multi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/multi/verify.groovy
+++ b/src/it/multi/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/nested/verify.groovy
+++ b/src/it/nested/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/no-src/pom.xml
+++ b/src/it/no-src/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/no-src/src/test/java/EmptyJUnitTest.java
+++ b/src/it/no-src/src/test/java/EmptyJUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/no-src/verify.groovy
+++ b/src/it/no-src/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/no-testsrc/pom.xml
+++ b/src/it/no-testsrc/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/no-testsrc/verify.groovy
+++ b/src/it/no-testsrc/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/omitVisitors/verify.groovy
+++ b/src/it/omitVisitors/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/onlyAnalyze/verify.groovy
+++ b/src/it/onlyAnalyze/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/onlyAnalyzeFileSource/verify.groovy
+++ b/src/it/onlyAnalyzeFileSource/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/pluginList-repo/verify.groovy
+++ b/src/it/pluginList-repo/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/pluginList/verify.groovy
+++ b/src/it/pluginList/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/relaxed/pom.xml
+++ b/src/it/relaxed/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/relaxed/verify.groovy
+++ b/src/it/relaxed/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/sarif-1/verify.groovy
+++ b/src/it/sarif-1/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/site-brazil/verify.groovy
+++ b/src/it/site-brazil/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/site-default/pom.xml
+++ b/src/it/site-default/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/site-default/verify.groovy
+++ b/src/it/site-default/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/site-french/pom.xml
+++ b/src/it/site-french/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/site-french/verify.groovy
+++ b/src/it/site-french/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/site-spanish/pom.xml
+++ b/src/it/site-spanish/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/site-spanish/verify.groovy
+++ b/src/it/site-spanish/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/skip/verify.groovy
+++ b/src/it/skip/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/skipEmpty/verify.groovy
+++ b/src/it/skipEmpty/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/systemPropertyVariables/verify.groovy
+++ b/src/it/systemPropertyVariables/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/threaded/verify.groovy
+++ b/src/it/threaded/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/threshold-experimental/pom.xml
+++ b/src/it/threshold-experimental/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/threshold-experimental/verify.groovy
+++ b/src/it/threshold-experimental/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/threshold-high/pom.xml
+++ b/src/it/threshold-high/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/threshold-high/verify.groovy
+++ b/src/it/threshold-high/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/threshold-low/pom.xml
+++ b/src/it/threshold-low/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/threshold-low/verify.groovy
+++ b/src/it/threshold-low/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/trace/verify.groovy
+++ b/src/it/trace/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/userPrefs-override/pom.xml
+++ b/src/it/userPrefs-override/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/userPrefs-override/verify.groovy
+++ b/src/it/userPrefs-override/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/userPrefs/pom.xml
+++ b/src/it/userPrefs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/userPrefs/verify.groovy
+++ b/src/it/userPrefs/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/verify-clean/pom.xml
+++ b/src/it/verify-clean/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/verify-clean/verify.groovy
+++ b/src/it/verify-clean/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/verify-fail/pom.xml
+++ b/src/it/verify-fail/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/verify-fail/verify.groovy
+++ b/src/it/verify-fail/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/it/verify/pom.xml
+++ b/src/it/verify/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2024 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/it/verify/verify.groovy
+++ b/src/it/verify/verify.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/CheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/CheckMojo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/PluginArtifact.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/PluginArtifact.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/VerifyMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/VerifyMojo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs.properties
+++ b/src/main/resources/spotbugs.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs_en.properties
+++ b/src/main/resources/spotbugs_en.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs_es.properties
+++ b/src/main/resources/spotbugs_es.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs_fr.properties
+++ b/src/main/resources/spotbugs_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs_no_NO.properties
+++ b/src/main/resources/spotbugs_no_NO.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/spotbugs_pt_BR.properties
+++ b/src/main/resources/spotbugs_pt_BR.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2023 the original author or authors.
+# Copyright 2005-2025 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/tools/spotbugs-exclude-filters.xml
+++ b/src/main/tools/spotbugs-exclude-filters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/css/apache-maven-fluido-1.12.0.min.css
+++ b/src/site/resources/examples/css/apache-maven-fluido-1.12.0.min.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/css/print.css
+++ b/src/site/resources/examples/css/print.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/css/site.css
+++ b/src/site/resources/examples/css/site.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/js/apache-maven-fluido-1.12.0.min.js
+++ b/src/site/resources/examples/js/apache-maven-fluido-1.12.0.min.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2023 the original author or authors.
+ * Copyright 2005-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/project-reports.html
+++ b/src/site/resources/examples/project-reports.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/spotbugs.html
+++ b/src/site/resources/examples/spotbugs.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/spotbugs.xml
+++ b/src/site/resources/examples/spotbugs.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref-test/allclasses-frame.html
+++ b/src/site/resources/examples/xref-test/allclasses-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref-test/index.html
+++ b/src/site/resources/examples/xref-test/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/App.html
+++ b/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/App.html
@@ -24,7 +24,7 @@
 <body>
 <div id="overview"><a href="../../../../../../testapidocs/org/codehaus/mojo/spotbugsmavenplugin/it/App.html">View Javadoc</a></div><pre>
 <a class="jxr_linenumber" name="L1" href="#L1">1</a>   <em class="jxr_comment">/*</em>
-<a class="jxr_linenumber" name="L2" href="#L2">2</a>   <em class="jxr_comment"> * Copyright 2005-2023 the original author or authors.</em>
+<a class="jxr_linenumber" name="L2" href="#L2">2</a>   <em class="jxr_comment"> * Copyright 2005-2025 the original author or authors.</em>
 <a class="jxr_linenumber" name="L3" href="#L3">3</a>   <em class="jxr_comment"> *</em>
 <a class="jxr_linenumber" name="L4" href="#L4">4</a>   <em class="jxr_comment"> * Licensed under the Apache License, Version 2.0 (the "License");</em>
 <a class="jxr_linenumber" name="L5" href="#L5">5</a>   <em class="jxr_comment"> * you may not use this file except in compliance with the License.</em>

--- a/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/FooTest.html
+++ b/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/FooTest.html
@@ -24,7 +24,7 @@
 <body>
 <div id="overview"><a href="../../../../../../testapidocs/org/codehaus/mojo/spotbugsmavenplugin/it/FooTest.html">View Javadoc</a></div><pre>
 <a class="jxr_linenumber" name="L1" href="#L1">1</a>   <em class="jxr_comment">/*</em>
-<a class="jxr_linenumber" name="L2" href="#L2">2</a>   <em class="jxr_comment"> * Copyright 2005-2023 the original author or authors.</em>
+<a class="jxr_linenumber" name="L2" href="#L2">2</a>   <em class="jxr_comment"> * Copyright 2005-2025 the original author or authors.</em>
 <a class="jxr_linenumber" name="L3" href="#L3">3</a>   <em class="jxr_comment"> *</em>
 <a class="jxr_linenumber" name="L4" href="#L4">4</a>   <em class="jxr_comment"> * Licensed under the Apache License, Version 2.0 (the "License");</em>
 <a class="jxr_linenumber" name="L5" href="#L5">5</a>   <em class="jxr_comment"> * you may not use this file except in compliance with the License.</em>

--- a/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/package-frame.html
+++ b/src/site/resources/examples/xref-test/org/codehaus/mojo/spotbugsmavenplugin/it/package-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref-test/overview-frame.html
+++ b/src/site/resources/examples/xref-test/overview-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/A.html
+++ b/src/site/resources/examples/xref/A.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/UselessFinalize.html
+++ b/src/site/resources/examples/xref/UselessFinalize.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/allclasses-frame.html
+++ b/src/site/resources/examples/xref/allclasses-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/annotations/package-frame.html
+++ b/src/site/resources/examples/xref/annotations/package-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/index.html
+++ b/src/site/resources/examples/xref/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/overview-frame.html
+++ b/src/site/resources/examples/xref/overview-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/site/resources/examples/xref/package-frame.html
+++ b/src/site/resources/examples/xref/package-frame.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2023 the original author or authors.
+    Copyright 2005-2025 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
doing so due to other branches I have having issues with copyright timestamps.  This will simply flush that through so I can not be bothered with that.