### PR TITLE
Cleanup encoding logic to speed it up

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -126,14 +126,13 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
     @Override
     void execute() {
 
-        AntBuilder ant = new AntBuilder()
-
         List<String> auxClasspathElements = session.getCurrentProject().compileClasspathElements
 
         if (debug) {
             log.debug('  Plugin Artifacts to be added -> ' + pluginArtifacts.toString())
         }
 
+        AntBuilder ant = new AntBuilder()
         ant.project.setProperty('basedir', spotbugsXmlOutputDirectory.getAbsolutePath())
         ant.project.setProperty('verbose', 'true')
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -132,19 +132,19 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
             log.debug('  Plugin Artifacts to be added -> ' + pluginArtifacts.toString())
         }
 
+        Charset effectiveEncoding
+        if (encoding) {
+            effectiveEncoding = Charset.forName(encoding)
+        } else {
+            effectiveEncoding = Charset.defaultCharset() ?: StandardCharsets.UTF_8
+        }
+        log.info('File Encoding is ' + effectiveEncoding.name())
+
         AntBuilder ant = new AntBuilder()
         ant.project.setProperty('basedir', spotbugsXmlOutputDirectory.getAbsolutePath())
         ant.project.setProperty('verbose', 'true')
 
         ant.java(classname: 'edu.umd.cs.findbugs.LaunchAppropriateUI', fork: 'true', failonerror: 'true', clonevm: 'true', maxmemory: "${maxHeap}m") {
-
-            Charset effectiveEncoding = Charset.defaultCharset() ?: StandardCharsets.UTF_8
-
-            if (encoding) {
-                effectiveEncoding = Charset.forName(encoding)
-            }
-
-            log.info('File Encoding is ' + effectiveEncoding.name())
 
             sysproperty(key: 'file.encoding' , value: effectiveEncoding.name())
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1033,7 +1033,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
         }
 
-
         log.info("Fork Value is ${fork}")
 
         long startTime
@@ -1043,17 +1042,17 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         List<String> spotbugsArgs = getSpotbugsArgs(htmlTempFile, xmlTempFile, sarifTempFile)
 
-        Charset effectiveEncoding = Charset.defaultCharset() ?: StandardCharsets.UTF_8
-
+        Charset effectiveEncoding
         if (sourceEncoding) {
             effectiveEncoding = Charset.forName(sourceEncoding)
+        } else {
+            effectiveEncoding = Charset.defaultCharset() ?: StandardCharsets.UTF_8
         }
+        log.debug('File Encoding is ' + effectiveEncoding.name())
 
         AntBuilder ant = new AntBuilder()
         ant.java(classname: 'edu.umd.cs.findbugs.FindBugs2', fork: "${fork}", failonerror: 'true',
                 clonevm: 'false', timeout: timeout, maxmemory: "${maxHeap}m") {
-
-            log.debug('File Encoding is ' + effectiveEncoding.name())
 
             sysproperty(key: 'file.encoding', value: effectiveEncoding.name())
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1033,7 +1033,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
         }
 
-        AntBuilder ant = new AntBuilder()
 
         log.info("Fork Value is ${fork}")
 
@@ -1050,6 +1049,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             effectiveEncoding = Charset.forName(sourceEncoding)
         }
 
+        AntBuilder ant = new AntBuilder()
         ant.java(classname: 'edu.umd.cs.findbugs.FindBugs2', fork: "${fork}", failonerror: 'true',
                 clonevm: 'false', timeout: timeout, maxmemory: "${maxHeap}m") {
 


### PR DESCRIPTION
previously always set value then if it was asked by user it was set again causing unnecessary garbage collection, moved it to be outside of ant in the one class so its used the same now in both places it existed (gui and mojo)