### PR TITLE
Fix usage of 'debug' flag vs 'logging debug flag' as they are not the…

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -130,8 +130,8 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 
         List<String> auxClasspathElements = session.getCurrentProject().compileClasspathElements
 
-        if (debug || log.isDebugEnabled()) {
-            log.debug("  Plugin Artifacts to be added -> ${pluginArtifacts}")
+        if (debug && log.isInfoEnabled()) {
+            log.info("  Plugin Artifacts to be added -> ${pluginArtifacts}")
         }
 
         Charset effectiveEncoding
@@ -182,8 +182,8 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
             classpath() {
 
                 pluginArtifacts.each() { Artifact pluginArtifact ->
-                    if (debug || log.isDebugEnabled()) {
-                        log.debug("  Trying to Add to pluginArtifact -> ${pluginArtifact.file}")
+                    if (debug && log.isInfoEnabled()) {
+                        log.info("  Trying to Add to pluginArtifact -> ${pluginArtifact.file}")
                     }
 
                     pathelement(location: pluginArtifact.file)

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1086,7 +1086,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         long startTime
-        if (log.isDebugEnabled()) {
+        if (debug) {
             startTime = System.nanoTime()
         }
 
@@ -1154,7 +1154,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         long duration
-        if (log.isDebugEnabled()) {
+        if (debug) {
             duration = (System.nanoTime() - startTime) / 1000000000.00
             log.debug("SpotBugs duration is ${duration}")
         }
@@ -1227,7 +1227,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
 
             // Do not delete file when running under debug mode
-            if (!log.isDebugEnabled()) {
+            if (!debug) {
                 xmlTempFile.delete()
             }
         }
@@ -1276,7 +1276,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
 
             // Do not delete file when running under debug mode
-            if (!log.isDebugEnabled()) {
+            if (!debug) {
                 sarifTempFile.delete()
             }
         }


### PR DESCRIPTION
… same

In multiple spots debug logging flags were used as if debugging spotbugs process, that was invalid.  Use proper debug flag to make it easier for users to debug.  None of that had direct relationship to logging outside of GUI but in that case, move logging to info level as it is unrelated to logging in that regard based on usage (although it logs).