### PR TITLE
Remove file optimizer logic in resource helper as it never did anything

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
@@ -75,16 +75,16 @@ final class ResourceHelper {
             log.debug("artifact is ${artifact}")
         }
 
-        File resourceFile = getResourceAsFile(resource, artifact)
+        Path resourcePath = getResourceAsFile(resource, artifact)
 
         if (log.isDebugEnabled()) {
-            log.debug("location of resourceFile file is ${resourceFile.absolutePath}")
+            log.debug("location of resourceFile file is ${resourcePath.toAbsolutePath()}")
         }
 
-        return resourceFile
+        return resourcePath.toFile()
     }
 
-    private File getResourceAsFile(final String name, final String outputPath) {
+    private Path getResourceAsFile(final String name, final String outputPath) {
         Path outputResourcePath
         if (outputDirectory != null) {
             outputResourcePath = outputDirectory.toPath().resolve(outputPath)
@@ -109,6 +109,6 @@ final class ResourceHelper {
             throw new MojoExecutionException('Cannot create file-based resource.', e)
         }
 
-        return outputResourcePath.toFile()
+        return outputResourcePath
     }
 }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/ResourceHelper.groovy
@@ -85,16 +85,6 @@ final class ResourceHelper {
     }
 
     private File getResourceAsFile(final String name, final String outputPath) {
-        // Optimization for File to File fetches
-        File file = new File(name)
-        if (file.exists() && outputPath == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("optimized file ${name}")
-            }
-            return file
-        }
-        // End optimization
-
         Path outputResourcePath
         if (outputDirectory != null) {
             outputResourcePath = outputDirectory.toPath().resolve(outputPath)


### PR DESCRIPTION
The original logic recently before I got rid of plexus call FileResourceLoader.getResourceAsFile(name, outputPath, outputDirectory) would check if 'name' exists as a file.  If outputPath, which is really just 'resource' and variation of resource as artifact for linux or windows, were null, it would return early thus optimization realized.  It otherwise would process the same logic using java rather than groovy that spotbugs was otherwise processing on its fall through.  So to get rid of plexus, the only logic thing was to check if outputPath was null but the crux of that is that it was never null all the way back to findbugs 2.5.3.  

So in plexus
* If name exists and outputPath was null, return the file of name.  Since outputPath could not ever be null even dating back to findbugs 2.5.3, that logic never did anything.  The same was true when coming back and further processing for the plexus tmp directory as it also was not possible to occur.
* If outputDirectory is not null, it would use that to calculate the outputFile, create directories and copy the file.  It was doing the same inside spotbugs.

Another way to say this is that if 'name' exists and outputPath is null, the optimization would have been appropriate to just return the file 'name'.  But given that was never possible, the logic was just duplication.  Its probable that even further back that findbugs had a reason for that but I stopped at the first tag of findbugs found in github.