### PR TITLE
fix integration test postBuildHookScript

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -993,7 +993,7 @@
                                     <pomIncludes>
                                         <pomInclude>*/pom.xml</pomInclude>
                                     </pomIncludes>
-                                    <postBuildHookScript>verify --no-transfer-progress</postBuildHookScript>
+                                    <postBuildHookScript>verify</postBuildHookScript>
                                     <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
                                     <goals>
                                         <goal>install</goal>
@@ -1014,7 +1014,7 @@
                                     <pomIncludes>
                                         <pomInclude>*/pom.xml</pomInclude>
                                     </pomIncludes>
-                                    <postBuildHookScript>verify --no-transfer-progress</postBuildHookScript>
+                                    <postBuildHookScript>verify</postBuildHookScript>
                                     <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
                                     <settingsFile>${project.basedir}/src/it/settings.xml</settingsFile>
                                     <streamLogsOnFailures>true</streamLogsOnFailures>


### PR DESCRIPTION
`<postBuildHookScript>` is not a maven goal / phase, but instead the name of a file, whose file extension may be omitted.

The intend is to find verify.groovy

```
[DEBUG] post-build script : no script 'verify --no-transfer-progress' found in directory C:\git\spotbugs-maven-plugin\target\it\exclude
```

Fix regression introduced in #1058.