### PR TITLE
Remove BugCollection internal check as its the only node, just directly check it

### DIFF
--- a/src/it/effort-default/verify.groovy
+++ b/src/it/effort-default/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert  path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@effort.text() == effortLevel
+assert path.@effort.text() == effortLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/effort-max/verify.groovy
+++ b/src/it/effort-max/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert  path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@effort.text() == effortLevel
+assert path.@effort.text() == effortLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/effort-min/verify.groovy
+++ b/src/it/effort-min/verify.groovy
@@ -67,6 +67,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert  path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@effort.text() == effortLevel
+assert path.@effort.text() == effortLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/experimental/verify.groovy
+++ b/src/it/experimental/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert  path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@threshold.text() == thresholdLevel
+assert path.@threshold.text() == thresholdLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/threshold-low/verify.groovy
+++ b/src/it/threshold-low/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@threshold.text() == thresholdLevel
+assert path.@threshold.text() == thresholdLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/userPrefs-override/verify.groovy
+++ b/src/it/userPrefs-override/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert  path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@effort.text() == effortLevel
+assert path.@effort.text() == effortLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/it/userPrefs/verify.groovy
+++ b/src/it/userPrefs/verify.groovy
@@ -68,6 +68,6 @@ allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
 println "BugInstance size is ${xdocErrors}"
 
-assert path.findAll { NodeChild node -> node.name() == 'BugCollection' }.@effort.text() == effortLevel
+assert path.@effort.text() == effortLevel
 
 assert xdocErrors == spotbugsXmlErrors

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/XDocsReporter.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/XDocsReporter.groovy
@@ -147,7 +147,7 @@ class XDocsReporter {
                     file(classname: bugClass) {
                         spotbugsResults.BugInstance.each() { NodeChild bugInstance ->
 
-                            if (bugInstance.Class.find{ NodeChild classNode -> classNode.@primary == "true" }.@classname.text() != bugClass) {
+                            if (bugInstance.Class.find { NodeChild classNode -> classNode.@primary == "true" }.@classname.text() != bugClass) {
                                 return
                             }
 


### PR DESCRIPTION
The original code looked at 'it' to find bug collection.  It is the only node and only one time in the file.  Since I'm trying to type everything, NodeChild doesn't work in this use case.  Most likely it needed rewritten to two lines.  However, there was no real reason to check that BugCollection existed when it just needs the effort level or threshold level and can directly access them.  This fixes current break on these tests from running.