### PR TITLE
Add logic to restore doxia 1 processing

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -555,7 +555,21 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             log.debug("canGenerate is ${canGenerate}")
         }
 
-        return canGenerate
+        boolean isSiteLifecycle = false;
+        if (session != null && session.getRequest() != null) {
+            List<String> goals = session.getRequest().getGoals();
+            if (goals != null && goals.any { String goal -> goal == "site" || goal.startsWith("site:") }) {
+                isSiteLifecycle = true;
+            }
+        }
+
+        if (canGenerate && !isSiteLifecycle) {
+            // Only generate xdoc report, skip site pages
+            generateXDoc(locale)
+            return false;
+        }
+
+        return canGenerate;
     }
 
     /**
@@ -627,7 +641,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      */
     @Override
     void executeReport(Locale locale) {
-
         log.debug('****** SpotBugsMojo executeReport *******')
         if (!canGenerateReport()) {
             return


### PR DESCRIPTION
no site reports unless site is actually called to generate.  original logic was removed as maven blocked usage of execute.  this restores the behaviour.

