### PR TITLE
Enforce XXE protections on xml parsing

### DIFF
--- a/src/it/basic-1/verify.groovy
+++ b/src/it/basic-1/verify.groovy
@@ -38,11 +38,15 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
 
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
 
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/change-xml-filename/verify.groovy
+++ b/src/it/change-xml-filename/verify.groovy
@@ -28,7 +28,10 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check-bug-file-multi-list/verify.groovy
+++ b/src/it/check-bug-file-multi-list/verify.groovy
@@ -31,7 +31,11 @@ println '**********************************'
 println 'Checking Spotbugs Native XML file '
 println '**********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -43,7 +47,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check-bug-file-multi/verify.groovy
+++ b/src/it/check-bug-file-multi/verify.groovy
@@ -31,7 +31,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -43,7 +47,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check-bug-file/verify.groovy
+++ b/src/it/check-bug-file/verify.groovy
@@ -31,7 +31,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -43,7 +47,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check-jvmargs/verify.groovy
+++ b/src/it/check-jvmargs/verify.groovy
@@ -31,7 +31,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -41,7 +45,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check-multi/verify.groovy
+++ b/src/it/check-multi/verify.groovy
@@ -26,7 +26,11 @@ import java.nio.file.Path
 Path spotbugXml = basedir.toPath().resolve('modules/module-1/target/spotbugsXml.xml')
 assert Files.exists(spotbugXml)
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 println '*********************************'
 println 'Checking Spotbugs Native XML file'
@@ -43,7 +47,7 @@ assert spotbugsErrors > 0
 spotbugXml = basedir.toPath().resolve('modules/module-2/target/spotbugsXml.xml')
 assert Files.exists(spotbugXml)
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 println '*********************************'
 println 'Checking Spotbugs Native XML file'

--- a/src/it/check-pluginList-repo/verify.groovy
+++ b/src/it/check-pluginList-repo/verify.groovy
@@ -30,7 +30,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -40,7 +44,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/check/verify.groovy
+++ b/src/it/check/verify.groovy
@@ -34,7 +34,10 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+GPathResult path =xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -44,7 +47,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/effort-default/verify.groovy
+++ b/src/it/effort-default/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/effort-max/verify.groovy
+++ b/src/it/effort-max/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'max'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/effort-min/verify.groovy
+++ b/src/it/effort-min/verify.groovy
@@ -37,10 +37,14 @@ String effortLevel = 'min'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -49,7 +53,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -61,7 +65,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/encoding-utf8/verify.groovy
+++ b/src/it/encoding-utf8/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/exclude-modules/verify.groovy
+++ b/src/it/exclude-modules/verify.groovy
@@ -26,12 +26,15 @@ import java.nio.file.Path
 Path spotbugXml = basedir.toPath().resolve('module1/target/spotbugsXml.xml')
 assert Files.exists(spotbugXml)
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
-
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -44,7 +47,7 @@ assert spotbugsErrors > 0
 spotbugXml = basedir.toPath().resolve('module2/target/spotbugsXml.xml')
 assert Files.exists(spotbugXml)
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 println '*********************************'
 println 'Checking Spotbugs Native XML file'

--- a/src/it/exclude-multi-list/verify.groovy
+++ b/src/it/exclude-multi-list/verify.groovy
@@ -35,20 +35,23 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
-
 
 println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -60,7 +63,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/exclude-multi/verify.groovy
+++ b/src/it/exclude-multi/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/exclude/verify.groovy
+++ b/src/it/exclude/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/excludeBugsFile/verify.groovy
+++ b/src/it/excludeBugsFile/verify.groovy
@@ -31,7 +31,11 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXdoc)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXdoc)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -41,7 +45,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/experimental/verify.groovy
+++ b/src/it/experimental/verify.groovy
@@ -38,10 +38,14 @@ println '******************'
 
 assert spotbugsHtml.text.contains('<i>' + thresholdLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/include-multi-list/verify.groovy
+++ b/src/it/include-multi-list/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for parsing HTML
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/include-multi/verify.groovy
+++ b/src/it/include-multi/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/include/verify.groovy
+++ b/src/it/include/verify.groovy
@@ -34,10 +34,14 @@ println '******************'
 println 'Checking HTML file'
 println '******************'
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -46,7 +50,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -58,7 +62,7 @@ println '***************************'
 println 'Checking xDoc file'
 println '***************************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/maxRank/verify.groovy
+++ b/src/it/maxRank/verify.groovy
@@ -31,7 +31,11 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXdoc)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXdoc)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -41,7 +45,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/multi-build/verify.groovy
+++ b/src/it/multi-build/verify.groovy
@@ -46,10 +46,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -75,7 +79,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -111,10 +115,10 @@ println '******************'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-path = xhtmlParser.parse(spotbugsHtml)
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -123,7 +127,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -140,7 +144,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 allNodes = path.depthFirst().toList()
 spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/multi/verify.groovy
+++ b/src/it/multi/verify.groovy
@@ -46,10 +46,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -58,7 +62,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(basedir.toPath().resolve("modules/${module}/target/spotbugs.xml"))
+path = xmlSlurper.parse(basedir.toPath().resolve("modules/${module}/target/spotbugs.xml"))
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -75,7 +79,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(basedir.toPath().resolve("modules/${module}/target/spotbugsXml.xml"))
+path = xmlSlurper.parse(basedir.toPath().resolve("modules/${module}/target/spotbugsXml.xml"))
 
 allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -111,10 +115,10 @@ println '******************'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-path = xhtmlParser.parse(spotbugsHtml)
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -123,7 +127,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -140,7 +144,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 allNodes = path.depthFirst().toList()
 spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/nested/verify.groovy
+++ b/src/it/nested/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/no-testsrc/verify.groovy
+++ b/src/it/no-testsrc/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/omitVisitors/verify.groovy
+++ b/src/it/omitVisitors/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -69,7 +73,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/onlyAnalyze/verify.groovy
+++ b/src/it/onlyAnalyze/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/onlyAnalyzeFileSource/verify.groovy
+++ b/src/it/onlyAnalyzeFileSource/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/pluginList-repo/verify.groovy
+++ b/src/it/pluginList-repo/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/pluginList/verify.groovy
+++ b/src/it/pluginList/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/relaxed/verify.groovy
+++ b/src/it/relaxed/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/site-brazil/verify.groovy
+++ b/src/it/site-brazil/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/site-default/verify.groovy
+++ b/src/it/site-default/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/site-french/verify.groovy
+++ b/src/it/site-french/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/site-spanish/verify.groovy
+++ b/src/it/site-spanish/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/skipEmpty/verify.groovy
+++ b/src/it/skipEmpty/verify.groovy
@@ -34,7 +34,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/threaded/verify.groovy
+++ b/src/it/threaded/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '***************************'
 println 'Checking xDoc file'
 println '***************************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/threshold-experimental/verify.groovy
+++ b/src/it/threshold-experimental/verify.groovy
@@ -38,10 +38,14 @@ String thresholdLevel = 'experimental'
 
 assert spotbugsHtml.text.contains('<i>' + thresholdLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/threshold-high/verify.groovy
+++ b/src/it/threshold-high/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE to parse the HTML file
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/threshold-low/verify.groovy
+++ b/src/it/threshold-low/verify.groovy
@@ -38,10 +38,14 @@ String thresholdLevel = 'low'
 
 assert spotbugsHtml.text.contains('<i>' + thresholdLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/trace/verify.groovy
+++ b/src/it/trace/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/userPrefs-override/verify.groovy
+++ b/src/it/userPrefs-override/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'max'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/userPrefs/verify.groovy
+++ b/src/it/userPrefs/verify.groovy
@@ -38,10 +38,14 @@ String effortLevel = 'default'
 
 assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
 
-XmlSlurper xhtmlParser = new XmlSlurper()
-xhtmlParser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
-xhtmlParser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
-GPathResult path = xhtmlParser.parse(spotbugsHtml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
 
 int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
 println "Error Count is ${spotbugsErrors}"
@@ -50,7 +54,7 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-path = new XmlSlurper().parse(spotbugXml)
+path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -62,7 +66,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/it/verify/verify.groovy
+++ b/src/it/verify/verify.groovy
@@ -34,7 +34,11 @@ println '*********************************'
 println 'Checking Spotbugs Native XML file'
 println '*********************************'
 
-GPathResult path = new XmlSlurper().parse(spotbugXml)
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+GPathResult path = xmlSlurper.parse(spotbugXml)
 
 List<NodeChild> allNodes = path.depthFirst().toList()
 int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
@@ -44,7 +48,7 @@ println '******************'
 println 'Checking xDoc file'
 println '******************'
 
-path = new XmlSlurper().parse(spotbugXdoc)
+path = xmlSlurper.parse(spotbugXdoc)
 
 allNodes = path.depthFirst().toList()
 int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -685,7 +685,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 generator.setLog(log)
                 generator.threshold = threshold
                 generator.effort = effort
-                generator.setSpotbugsResults(new XmlSlurper().parse(outputSpotbugsFile))
+
+                XmlSlurper xmlSlurper = new XmlSlurper()
+                xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+                xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+                generator.setSpotbugsResults(xmlSlurper.parse(outputSpotbugsFile))
                 generator.setOutputDirectory(new File(outputDirectory.getAbsolutePath()))
                 generator.generateReport()
 
@@ -727,7 +732,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             XDocsReporter xDocsReporter = new XDocsReporter(getBundle(locale), log, threshold, effort, outputEncoding)
             xDocsReporter.setOutputWriter(Files.newBufferedWriter(Path.of("${xmlOutputDirectory}/spotbugs.xml"),
                 Charset.forName(outputEncoding)))
-            xDocsReporter.setSpotbugsResults(new XmlSlurper().parse(outputSpotbugsFile))
+
+            XmlSlurper xmlSlurper = new XmlSlurper()
+            xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+            xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+            xDocsReporter.setSpotbugsResults(xmlSlurper.parse(outputSpotbugsFile))
             xDocsReporter.setCompileSourceRoots(session.getCurrentProject().compileSourceRoots)
             xDocsReporter.setTestSourceRoots(session.getCurrentProject().testCompileSourceRoots)
 
@@ -1186,7 +1196,11 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         if (xmlTempFile.exists()) {
             if (xmlTempFile.size() > 0) {
-                GPathResult path = new XmlSlurper().parse(xmlTempFile)
+                XmlSlurper xmlSlurper = new XmlSlurper()
+                xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+                xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+                GPathResult path = xmlSlurper.parse(xmlTempFile)
 
                 List<NodeChild> allNodes = path.depthFirst().toList()
 

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotbugsReportGeneratorTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotbugsReportGeneratorTest.groovy
@@ -15,6 +15,8 @@
  */
 package org.codehaus.mojo.spotbugs
 
+import groovy.xml.XmlSlurper
+
 import org.apache.maven.doxia.sink.Sink
 import org.apache.maven.plugin.logging.Log
 
@@ -55,7 +57,12 @@ class SpotbugsReportGeneratorTest extends Specification {
         generator.outputDirectory = new File('.')
         generator.xrefLocation = new File('.')
         generator.xrefTestLocation = new File('.')
-        generator.spotbugsResults = new groovy.xml.XmlSlurper().parseText('''
+
+        XmlSlurper xmlSlurper = new XmlSlurper()
+        xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+        xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+        generator.spotbugsResults = xmlSlurper.parseText('''
             <BugCollection>
                 <FindBugsSummary total_classes='1' total_bugs='1'>
                     <PackageStats>

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/XDocsReporterTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/XDocsReporterTest.groovy
@@ -69,7 +69,12 @@ class XDocsReporterTest extends Specification {
                 </Error>
             </BugCollection>
         '''
-        reporter.spotbugsResults = new XmlSlurper().parseText(xml)
+
+        XmlSlurper xmlSlurper = new XmlSlurper()
+        xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+        xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+        reporter.spotbugsResults = xmlSlurper.parseText(xml)
 
         when:
         reporter.generateReport()


### PR DESCRIPTION
xml files need the protection.

in integration tests, they run xml parsing on html files.  html files don't have the issue but also we cannot force maven doxia to not apply doctype, so those are wrapped when being used to allow the doctype setting.  As for spotbugs, it doesn't add the doctype nor should have any entity so its good to block any potential so that applies to the source processing.