### PR TITLE
Resolve issue #75 by adding log when no files found to run on spotbugs

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -563,10 +563,14 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
         }
 
-        if (canGenerate && !isSiteLifecycle) {
-            // Only generate xdoc report, skip site pages
-            generateXDoc(getLocale())
-            return false;
+        if (canGenerate) {
+            if (!isSiteLifecycle) {
+                // Only generate xdoc report, skip site pages
+                generateXDoc(getLocale())
+                return false;
+            }
+        } else {
+            log.info('No files found to run spotbugs, check compile phase has been run')
         }
 
         return canGenerate;


### PR DESCRIPTION
Fixes #75 

Add helper when compile not ran as suggested on #75 