### PR TITLE
add support for SpotBugs' chooseVisitors parameter

### DIFF
--- a/src/it/chooseVisitors/invoker.properties
+++ b/src/it/chooseVisitors/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2005-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean compile site --no-transfer-progress
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/chooseVisitors/pom.xml
+++ b/src/it/chooseVisitors/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2025 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>testing</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+
+  <artifactId>chooseVisitors</artifactId>
+  <name>chooseVisitors</name>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxr.plugin@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <chooseVisitors>-FindDeadLocalStores,+TestASM,-UnreadFields</chooseVisitors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/chooseVisitors/src/site/site.xml
+++ b/src/it/chooseVisitors/src/site/site.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2025 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<site name="${project.name}" xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+
+  <bannerLeft name="SpotBugs Maven Plugin" />
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>2.1.0</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>false</topBarEnabled>
+      <sideBarEnabled>false</sideBarEnabled>
+      <breadcrumbDivider>»</breadcrumbDivider>
+      <gitHub>
+        <projectId>spotbugs/spotbugs-maven-plugin</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>red</ribbonColor>
+      </gitHub>
+      <ohloh>
+        <projectId>spotbugs-maven-plugin</projectId>
+        <widget>thin-badge</widget>
+      </ohloh>
+    </fluidoSkin>
+  </custom>
+
+  <publishDate format="yyyy-MM-dd" position="right"/>
+  <version position="right"/>
+
+</site>

--- a/src/it/chooseVisitors/verify.groovy
+++ b/src/it/chooseVisitors/verify.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2005-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import groovy.xml.slurpersupport.NodeChild
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+Path spotbugsHtml =  basedir.toPath().resolve('target/site/spotbugs.html')
+assert Files.exists(spotbugsHtml)
+
+Path spotbugsXdoc = basedir.toPath().resolve('target/spotbugs.xml')
+assert Files.exists(spotbugsXdoc)
+
+Path spotbugsXml = basedir.toPath().resolve('target/spotbugsXml.xml')
+assert Files.exists(spotbugsXml)
+
+println '******************'
+println 'Checking HTML file'
+println '******************'
+
+String effortLevel = 'default'
+
+assert spotbugsHtml.text.contains('<i>' + effortLevel + '</i>')
+
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+
+int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+println '*********************************'
+println 'Checking Spotbugs Native XML file'
+println '*********************************'
+
+path = xmlSlurper.parse(spotbugsXml)
+
+List<NodeChild> allNodes = path.depthFirst().toList()
+int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+assert spotbugsXmlErrors == spotbugsErrors
+
+spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'URF_UNREAD_FIELD' }
+spotbugsXmlErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'UUF_UNUSED_FIELD'}
+spotbugsXmlErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'DLS_DEAD_LOCAL_STORE'}
+println "BugInstance size from detectors removed is ${spotbugsXmlErrors}"
+
+assert 0 == spotbugsXmlErrors
+
+spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'NM_METHOD_NAMING_CONVENTION'}
+spotbugsXmlErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL'}
+spotbugsXmlErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'NM_FIELD_NAMING_CONVENTION'}
+println "BugInstance size from detectors removed is ${spotbugsXmlErrors}"
+
+assert 0 != spotbugsXmlErrors
+
+println '******************'
+println 'Checking xDoc file'
+println '******************'
+
+path = xmlSlurper.parse(spotbugsXdoc)
+
+allNodes = path.depthFirst().toList()
+int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
+println "BugInstance size is ${xdocErrors}"
+
+assert xdocErrors == spotbugsErrors
+
+xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'URF_UNREAD_FIELD' }
+xdocErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'UUF_UNUSED_FIELD'}
+xdocErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'DLS_DEAD_LOCAL_STORE'}
+println "BugInstance size from detectors removed is ${xdocErrors}"
+
+assert 0 == xdocErrors
+
+xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'NM_METHOD_NAMING_CONVENTION'}
+xdocErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL'}
+xdocErrors += allNodes.count { NodeChild node -> node.name() == 'BugInstance'  && node.@type == 'NM_FIELD_NAMING_CONVENTION'}
+println "BugInstance size from detectors removed is ${xdocErrors}"
+
+assert 0 != spotbugsXmlErrors

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -341,6 +341,14 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     String omitVisitors
 
     /**
+     * Selectively enable/disable detectors. This is a comma-delimited list with "+" or "-" before each detectors name indicated enabling or disabling.
+     *
+     * @since 4.9.4.2
+     */
+    @Parameter(property = 'spotbugs.chooseVisitors')
+    String chooseVisitors
+
+    /**
      * The plugin list to include in the report. This is a comma-delimited list.
      * <p>
      * Potential values are a filesystem path, a URL, or a classpath resource.
@@ -884,6 +892,12 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             log.debug("  Adding 'omitVisitors'")
             args << '-omitVisitors'
             args << omitVisitors
+        }
+
+        if (chooseVisitors) {
+            log.debug("  Adding 'chooseVisitors'")
+            args << '-chooseVisitors'
+            args << chooseVisitors
         }
 
         if (relaxed) {


### PR DESCRIPTION
The SpotBugs maven plugin does not support currently SpotBugs' `chooseVisitors` parameter, which provides the possibility to enable and disable detectors. Without this it's not possible to run a detectors disabled by default together with all enabled detectors without specifying all detectors. This PR resolves this problem.
The `chooseVisitors` parameter in the [SpotBugs official documentation](https://spotbugs.readthedocs.io/en/latest/running.html#detector-visitor-configuration-options).

Closes https://github.com/spotbugs/spotbugs-maven-plugin/issues/795.