### PR TITLE
Update maven wrapper content

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
--XX:+TieredCompilation -XX:TieredStopAtLevel=1 --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-XX:TieredStopAtLevel=1

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -117,6 +117,7 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+
 @REM Maven main class is here to fix maven 4.0.0-beta-5 through 4.0.0-rc-4
 set MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain


### PR DESCRIPTION
- Remove tiered compilation as not needed java 11 or better as that is the default
- Remove add opens against java.io, java.lang, and java.util as no longer needed

