### PR TITLE
fix: discover source jar/zip files if nested attribute is set

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsInfo.groovy
@@ -59,6 +59,10 @@ interface SpotBugsInfo {
 
     /** The static class suffix. */
     static final String CLASS_SUFFIX = '.class'
+    /** The static jar suffix. */
+    static final String JAR_SUFFIX = '.jar'
+    /** The static zip suffix. */
+    static final String ZIP_SUFFIX = '.zip'
 
     /** The spotbugs efforts as max, min, and default as default. */
     Map<String, String> spotbugsEfforts = [Max: 'max', Min: 'min', Default: 'default']


### PR DESCRIPTION
Via the `nested` option Spotbugs has support for processing class files that are packed in zip/jar archives. In the `canGenerate` method this plugin however only checks if there are any `.class` files in the source directory and does not check for `.jar` or `.zip` archives. If there are no matching files found, it will not even call spotbugs with, thus basically breaking support for the nested option in the maven plugin. I believe this to be a bug.

I added additional checks for archive file-types which also respect whether nested is set or not. I also corrected the fact that previously the check allowed for the extension to be anywhere in the filename and not just at the end, i.e. perviously `MyFile.class.foo` would have been matched but will not be with this patch.