### PR TITLE
Inner class xref links #1316

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsReportGenerator.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotbugsReportGenerator.groovy
@@ -162,7 +162,7 @@ class SpotbugsReportGenerator implements SpotBugsInfo {
     List<String> bugClasses = []
 
     /** Pre-compiled pattern for removing inner class suffixes. */
-    private static final Pattern INNER_CLASS_PATTERN = Pattern.compile('\$.*')
+    private static final Pattern INNER_CLASS_PATTERN = Pattern.compile('\\$.*')
 
     /**
      * Default constructor.


### PR DESCRIPTION
Updated string for `Pattern.compile` for regex match.

Tested the update for both normal classes and also inner classes that have spotbugs results to ensure the xref links for both works properly.