### PR TITLE
[fix] Toolchain used wrong flag name 'executable' instead of 'jvm'

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -174,7 +174,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
             String javaExecutable = toolchain.findTool('java')
             if (javaExecutable) {
                 log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
-                javaTaskParams['executable'] = javaExecutable
+                javaTaskParams['jvm'] = javaExecutable
             }
         }
         ant.java(javaTaskParams) {

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1264,7 +1264,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         if (javaExecutable) {
             if (fork) {
                 log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
-                javaTaskParams['executable'] = javaExecutable
+                javaTaskParams['jvm'] = javaExecutable
             } else {
                 log.warn('Toolchain is configured but fork is disabled. The toolchain JVM will not be used.')
             }


### PR DESCRIPTION
fixes issue #1427