### PR TITLE
modify renovate config to not use bytebuddy -jdk5 postifx versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+  ],
+
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "net.bytebuddy:byte-buddy",
+        "net.bytebuddy:byte-buddy-agent"
+      ],
+      "allowedVersions": "!/.*-jdk5$/"
+    }
   ]
 }


### PR DESCRIPTION
Byte-buddy is releasing two versions: `x.y.z` and `x.y.z-jdk5`, with the only change being the latter is compatible with JDK5. See https://github.com/raphw/byte-buddy/issues/1889 and https://github.com/raphw/byte-buddy/issues/1917. 
Renovate does not recognize these correctly and wants to update to the jdk5 version (see https://github.com/spotbugs/spotbugs-maven-plugin/pull/1449 and https://github.com/spotbugs/spotbugs-maven-plugin/pull/1414).
This PR configures renovate to not use the versions with `-jdk5` postfix for byte-buddy.