### PR TITLE
Correct 2 integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1132,6 +1132,9 @@
                                 <configuration>
                                     <projectsDirectory>${project.basedir}/src/it</projectsDirectory>
                                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                                    <filterProperties>
+                                        <java.specification.version>${java.specification.version}</java.specification.version>
+                                    </filterProperties>
                                     <showVersion>true</showVersion>
                                     <pomIncludes>
                                         <pomInclude>*/pom.xml</pomInclude>

--- a/src/it/check-toolchain/invoker.properties
+++ b/src/it/check-toolchain/invoker.properties
@@ -6,7 +6,7 @@
 #
 
 invoker.goals = clean compile spotbugs:check --no-transfer-progress
-invoker.toolchain.jdk.version = @java.specification.version@
+invoker.toolchain.jdk.version = ${java.specification.version}
 
 # The expected result of the build, possible values are "success" (default) and "failure"
 invoker.buildResult = success

--- a/src/it/systemPropertyVariables/verify.groovy
+++ b/src/it/systemPropertyVariables/verify.groovy
@@ -8,4 +8,4 @@ import java.nio.file.Path
 import java.nio.charset.StandardCharsets
 
 Path buildLog = basedir.toPath().resolve('build.log')
-assert buildLog.getText(StandardCharsets.UTF_8.name()).contains('[java] INFO: System variables are considered to be tainted')
+assert buildLog.getText(StandardCharsets.UTF_8.name()).contains('INFO: System variables are considered to be tainted')


### PR DESCRIPTION
- toolchain test was being skipped due to filtering issues, corrected
- tainted system properties was relying on 'java' wrap of message from ant, fixed that so its not dependent on ant wrapping