### PR TITLE
Make tool chain logic more robust

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -159,16 +159,23 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
         ant.project.setProperty('basedir', spotbugsXmlOutputDirectory.getAbsolutePath())
         ant.project.setProperty('verbose', 'true')
 
-        Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
         Map<String, Object> javaTaskParams = [classname: 'edu.umd.cs.findbugs.LaunchAppropriateUI',
                 fork: 'true', failonerror: 'true', clonevm: 'true', maxmemory: "${maxHeap}m"]
-        if (toolchain) {
-            String javaExecutable = toolchain.findTool('java')
-            if (javaExecutable) {
+
+        Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
+
+        String javaExecutable = "java"
+
+        if (toolchain != null) {
+            String toolchainPath = toolchain?.findTool('java')
+            if (toolchainPath != null) {
                 log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
-                javaTaskParams['jvm'] = javaExecutable
+                javaExecutable = toolchainPath
             }
         }
+
+        javaTaskParams['jvm'] = javaExecutable
+
         ant.java(javaTaskParams) {
 
             sysproperty(key: 'file.encoding' , value: effectiveEncoding.name())

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1251,16 +1251,25 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         AntBuilder ant = new AntBuilder()
         Map<String, Object> javaTaskParams = [classname: 'edu.umd.cs.findbugs.FindBugs2', fork: "${fork}",
                 failonerror: 'true', clonevm: 'false', timeout: timeout, maxmemory: "${maxHeap}m"]
+
         Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
-        String javaExecutable = toolchain?.findTool('java')
-        if (javaExecutable) {
-            if (fork) {
-                log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
-                javaTaskParams['jvm'] = javaExecutable
-            } else {
-                log.warn('Toolchain is configured but fork is disabled. The toolchain JVM will not be used.')
+
+        String javaExecutable = 'java'
+
+        if (toolchain != null) {
+            String toolchainPath = toolchain?.findTool('java')
+            if (toolchainPath != null) {
+                if (fork) {
+                    log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
+                    javaExecutable = toolchainPath
+                } else {
+                    log.warn('Toolchain is configured but fork is disabled. The toolchain JVM will not be used.')
+                }
             }
         }
+
+        javaTaskParams['jvm'] = javaExecutable
+
         ant.java(javaTaskParams) {
 
             sysproperty(key: 'file.encoding', value: effectiveEncoding.name())

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -1512,19 +1512,4 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         this.outputDirectory = reportOutputDirectory
     }
 
-    /**
-     * Gets the Java executable to use for the forked SpotBugs process.
-     * If a JDK toolchain is configured for the build, the executable from that toolchain is returned.
-     * Otherwise, returns {@code null} and the default JVM will be used.
-     *
-     * @return the java executable path from the toolchain, or {@code null} if no toolchain is configured
-     * @since 4.9.8.4
-     */
-    String getJavaExecutable() {
-        Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
-        if (toolchain) {
-            return toolchain.findTool('java')
-        }
-        return null
-    }
 }

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
@@ -258,57 +258,6 @@ class SpotBugsMojoTest extends Specification {
         new SpotBugsMojo().getOutputPath() == SpotBugsInfo.PLUGIN_NAME
     }
 
-    void 'getJavaExecutable returns null when no toolchain is configured'() {
-        given:
-        MavenSession session = Mock(MavenSession)
-        ToolchainManager toolchainManager = Mock(ToolchainManager) {
-            getToolchainFromBuildContext('jdk', session) >> null
-        }
-        SpotBugsMojo mojo = new SpotBugsMojo()
-        mojo.session = session
-        mojo.toolchainManager = toolchainManager
-
-        when:
-        String result = mojo.getJavaExecutable()
-
-        then:
-        result == null
-    }
-
-    void 'getJavaExecutable returns null when toolchainManager is null'() {
-        given:
-        SpotBugsMojo mojo = new SpotBugsMojo()
-        mojo.session = Mock(MavenSession)
-        mojo.toolchainManager = null
-
-        when:
-        String result = mojo.getJavaExecutable()
-
-        then:
-        result == null
-    }
-
-    void 'getJavaExecutable returns java executable from configured toolchain'() {
-        given:
-        String expectedJavaPath = '/usr/lib/jvm/java-11/bin/java'
-        MavenSession session = Mock(MavenSession)
-        Toolchain toolchain = Mock(Toolchain) {
-            findTool('java') >> expectedJavaPath
-        }
-        ToolchainManager toolchainManager = Mock(ToolchainManager) {
-            getToolchainFromBuildContext('jdk', session) >> toolchain
-        }
-        SpotBugsMojo mojo = new SpotBugsMojo()
-        mojo.session = session
-        mojo.toolchainManager = toolchainManager
-
-        when:
-        String result = mojo.getJavaExecutable()
-
-        then:
-        result == expectedJavaPath
-    }
-
     // -------------------------------------------------------------------------
     // getThresholdParameter() – threshold value mapping
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Refactored Java executable selection so both GUI and Mojo executions consistently resolve the configured Maven JDK toolchain. Removed unused helper logic that was not connected to process execution. This ensures toolchain configuration is applied at the point where the SpotBugs JVM is launched.

Java executable selection is now explicit for all executions. Previously the JVM executable was only set when a Maven toolchain was configured, relying on the underlying execution mechanism to supply the default Java. The launcher now always receives an executable (java by default or the configured toolchain executable).