### PR TITLE
[pom] Use jar plugin to zip groovy docs so reproducibility works

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,18 @@ E.g. to set the findbugs.assertionmethods analyzer property:
     </configuration>
 </plugin>
 ```
-## Reproduciblity ##
 
-To run reproducibility checks, you can execute the following.  Its best to checkout the 'tag' first and make sure your maven and jdk revisions match what was used for the release.
+## Reproducible Builds ##
+
+To run reproducibility checks against an official release, execute the following command. It is best to check out the specific release tag first and ensure your Maven and JDK versions match what was used for that release:
 
 ```
 mvn clean verify artifact:compare -D"reference.repo=https://repo.maven.apache.org/maven2/"
+```
+
+To validate reproducibility locally on your current branch before a release, execute this two-step loop. This uses your local .m2 cache as a reference baseline without overwriting it on the second pass:
+
+```
+ mvn clean install
+ mvn clean verify artifact:compare -D"reference.repo=file:///${user.home}/.m2/repository/"
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -791,26 +791,12 @@
                         <phase>prepare-package</phase>
                     </execution>
                     <execution>
-                        <id>generate-groovydoc-jars</id>
-                        <goals>
-                            <goal>groovydoc-jar</goal>
-                            <goal>groovydocTests-jar</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <!-- Do not re-invoke groovydoc: HTML was already generated and timestamps stripped -->
-                            <invokeGroovyDoc>false</invokeGroovyDoc>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>site</id>
                         <goals>
                             <goal>generateStubs</goal>
                             <goal>generateTestStubs</goal>
                             <goal>groovydoc</goal>
                             <goal>groovydocTests</goal>
-                            <goal>groovydoc-jar</goal>
-                            <goal>groovydocTests-jar</goal>
                         </goals>
                         <phase>site</phase>
                     </execution>
@@ -888,6 +874,38 @@
                             <arguments>
                                 <argument>${project.build.directory}/generated-sources/groovy-stubs/test</argument>
                             </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-reproducible-groovydoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>groovydoc</classifier>
+                            <classesDirectory>${project.build.directory}/site/gapidocs</classesDirectory>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>package-reproducible-test-groovydoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>test-groovydoc</classifier>
+                            <classesDirectory>${project.build.directory}/site/testgapidocs</classesDirectory>
+                            <skipIfEmpty>true</skipIfEmpty>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
fixes #1148

Per instructions here, running off current branch fix here, the following results occur.

```
[Reproducible Builds] rebuild comparison result: 9 files match
```