### PR TITLE
Replace 'ant' based SpotBugs execution with ProcessBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
         <log4j2.version>2.26.1</log4j2.version>
         <slf4jVersion>2.0.18</slf4jVersion>
 
-        <antVersion>1.10.17</antVersion>
         <groovyVersion>5.0.7</groovyVersion>
         <javaparserVersion>3.28.2</javaparserVersion>
 
@@ -264,13 +263,6 @@
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
                 <version>${saxon.he.version}</version>
-            </dependency>
-
-            <!-- Override 'ant' used in groovy to latest -->
-            <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant</artifactId>
-                <version>${antVersion}</version>
             </dependency>
 
             <!-- Commons -->
@@ -453,22 +445,6 @@
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <exclusions>
-                <!-- We do not need these items from groovy ant -->
-                <exclusion>
-                    <groupId>org.apache.ant</groupId>
-                    <artifactId>ant-antlr</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.ant</groupId>
-                    <artifactId>ant-junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Groovy quirk requires compile scope so optional makes it not show up in consumer builds. -->

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -6,8 +6,6 @@
  */
 package org.codehaus.mojo.spotbugs
 
-import groovy.ant.AntBuilder
-
 import java.awt.GraphicsEnvironment
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
@@ -155,12 +153,13 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
             spotbugsArgs << getSpotbugsPlugins()
         }
 
-        AntBuilder ant = new AntBuilder()
-        ant.project.setProperty('basedir', spotbugsXmlOutputDirectory.getAbsolutePath())
-        ant.project.setProperty('verbose', 'true')
-
-        Map<String, Object> javaTaskParams = [classname: 'edu.umd.cs.findbugs.LaunchAppropriateUI',
-                fork: 'true', failonerror: 'true', clonevm: 'true', maxmemory: "${maxHeap}m"]
+        Path spotbugsXml = spotbugsXmlOutputDirectory.toPath().resolve(spotbugsXmlOutputFilename)
+        if (Files.exists(spotbugsXml)) {
+            if (log.isDebugEnabled()) {
+                log.debug("  Found an SpotBugs XML at -> ${spotbugsXml}")
+            }
+            spotbugsArgs << spotbugsXml.toString()
+        }
 
         Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
 
@@ -174,41 +173,41 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
             }
         }
 
-        javaTaskParams['jvm'] = javaExecutable
+        // Build classpath
+        List<String> classpathElements = pluginArtifacts.collect { Artifact pluginArtifact -> pluginArtifact.file.getAbsolutePath() }
+        String classpath = classpathElements.join(File.pathSeparator)
 
-        ant.java(javaTaskParams) {
+        // Build command
+        List<String> command = []
+        command << javaExecutable
+        command << "-Xmx${maxHeap}m"
+        command << "-Dfile.encoding=${effectiveEncoding.name()}"
+        command << '-Dfindbugs.launchUI=gui2'
+        command << '-cp'
+        command << classpath
+        command << 'edu.umd.cs.findbugs.LaunchAppropriateUI'
+        command.addAll(spotbugsArgs)
 
-            sysproperty(key: 'file.encoding' , value: effectiveEncoding.name())
+        List<String> sanitizedCommand = command.collect(Object::toString)
 
-            // spotbugs assumes that multiple arguments (because of options) means text mode, so need to request gui explicitly
-            jvmarg(value: '-Dfindbugs.launchUI=gui2')
+        if (debug && log.isInfoEnabled()) {
+            log.info("Launching SpotBugs GUI with command: ${sanitizedCommand}")
+        }
 
-            spotbugsArgs.each { String spotbugsArg ->
-                if (log.isDebugEnabled()) {
-                    log.debug("Spotbugs arg is ${spotbugsArg}")
-                }
-                arg(value: spotbugsArg)
-            }
-
-            Path spotbugsXml = spotbugsXmlOutputDirectory.toPath().resolve(spotbugsXmlOutputFilename)
-
-            if (Files.exists(spotbugsXml)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("  Found an SpotBugs XML at -> ${spotbugsXml}")
-                }
-                arg(value: spotbugsXml)
-            }
-
-            classpath() {
-
-                pluginArtifacts.each() { Artifact pluginArtifact ->
-                    if (debug && log.isInfoEnabled()) {
-                        log.info("  Trying to Add to pluginArtifact -> ${pluginArtifact.file}")
-                    }
-
-                    pathelement(location: pluginArtifact.file)
+        ProcessBuilder pb = new ProcessBuilder(sanitizedCommand)
+        pb.directory(spotbugsXmlOutputDirectory)
+        pb.redirectErrorStream(true)
+        Process process = pb.start()
+        process.inputStream.withReader(effectiveEncoding.name()) { reader ->
+            reader.eachLine { line ->
+                if (log.isInfoEnabled()) {
+                    log.info(line)
                 }
             }
+        }
+        int exitCode = process.waitFor()
+        if (exitCode != 0) {
+            log.error("SpotBugs GUI exited with code: ${exitCode}")
         }
     }
 }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -6,7 +6,6 @@
  */
 package org.codehaus.mojo.spotbugs
 
-import groovy.ant.AntBuilder
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.xml.XmlSlurper
@@ -19,6 +18,7 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import java.util.function.Predicate
 import java.util.jar.JarFile
 import java.util.stream.Collectors
@@ -437,14 +437,15 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     /**
      * Fork a VM for Spotbugs analysis.  This will allow you to set timeouts and heap size.
      *
+     * @deprecated Parameter 'fork' is deprecated and ignored. SpotBugs is always executed in a separate process.
      * @since 2.3.2
      */
+    @Deprecated(forRemoval = true, since = '4.10.3.0')
     @Parameter(defaultValue = 'true', property = 'spotbugs.fork')
     boolean fork
 
     /**
      * Maximum Java heap size in megabytes  (default=512).
-     * This only works if the <b>fork</b> parameter is set <b>true</b>.
      *
      * @since 2.2
      */
@@ -455,7 +456,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
      * Specifies the amount of time, in milliseconds, that Spotbugs may run before
      * it is assumed to be hung and is terminated.
      * The default is 600,000 milliseconds, which is ten minutes.
-     * This only works if the <b>fork</b> parameter is set <b>true</b>.
      *
      * @since 2.2
      */
@@ -463,7 +463,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     int timeout
 
     /**
-     * The arguments to pass to the forked VM (ignored if fork is disabled).
+     * The arguments to pass to the forked VM.
      *
      * @since 2.4.1
      */
@@ -493,7 +493,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     String userPrefs
 
     /**
-     * System properties to set in the VM (or the forked VM if fork is enabled).
+     * System properties to set in the VM.
      *
      * @since 4.3.0
      */
@@ -1223,10 +1223,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             }
         }
 
-        if (log.isInfoEnabled()) {
-            log.info("Fork Value is ${fork}")
-        }
-
         long startTime
         if (debug) {
             startTime = System.nanoTime()
@@ -1246,10 +1242,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
             log.debug('File Encoding is ' + effectiveEncoding.name())
         }
 
-        AntBuilder ant = new AntBuilder()
-        Map<String, Object> javaTaskParams = [classname: 'edu.umd.cs.findbugs.FindBugs2', fork: "${fork}",
-                failonerror: 'true', clonevm: 'false', timeout: timeout, maxmemory: "${maxHeap}m"]
-
         Toolchain toolchain = toolchainManager?.getToolchainFromBuildContext('jdk', session)
 
         String javaExecutable = 'java'
@@ -1257,63 +1249,73 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         if (toolchain != null) {
             String toolchainPath = toolchain.findTool('java')
             if (toolchainPath != null) {
-                if (fork) {
-                    log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
-                    javaExecutable = toolchainPath
-                } else {
-                    log.warn('Toolchain is configured but fork is disabled. The toolchain JVM will not be used.')
-                }
+                log.info("Toolchain in spotbugs-maven-plugin: ${toolchain}")
+                javaExecutable = toolchainPath
             }
         }
 
-        javaTaskParams['jvm'] = javaExecutable
+        // Build classpath from pluginArtifacts
+        List<String> classpathElements = pluginArtifacts.collect { Artifact pluginArtifact -> pluginArtifact.file.getAbsolutePath() }
+        String classpath = classpathElements.join(File.pathSeparator)
 
-        ant.java(javaTaskParams) {
-
-            sysproperty(key: 'file.encoding', value: effectiveEncoding.name())
-
-            if (jvmArgs && fork) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Adding JVM Args => ${jvmArgs}")
-                }
-
-                List<String> args = Arrays.asList(jvmArgs.split(SpotBugsInfo.BLANK))
-
-                args.each() { String jvmArg ->
-                    if (log.isDebugEnabled()) {
-                        log.debug("Adding JVM Arg => ${jvmArg}")
-                    }
-                    jvmarg(value: jvmArg)
-                }
+        // Build JVM args
+        List<String> jvmArgsList = []
+        if (jvmArgs) {
+            if (log.isDebugEnabled()) {
+                log.debug("Adding JVM Args => ${jvmArgs}")
             }
-
-            if (debug || trace) {
-                sysproperty(key: 'findbugs.debug', value: Boolean.TRUE)
+            jvmArgsList.addAll(jvmArgs.split(SpotBugsInfo.BLANK))
+        }
+        jvmArgsList << "-Dfile.encoding=${effectiveEncoding.name()}"
+        if (debug || trace) {
+            jvmArgsList << "-Dfindbugs.debug=true"
+        }
+        systemPropertyVariables.each { Map.Entry<String, String> sysProp ->
+            if (log.isDebugEnabled()) {
+                log.debug("System property ${sysProp.key} is ${sysProp.value}")
             }
+            jvmArgsList << "-D${sysProp.key}=${sysProp.value}"
+        }
 
-            classpath() {
+        // Build command
+        List<String> command = []
+        command << javaExecutable
+        command << "-Xmx${maxHeap}m"
+        command.addAll(jvmArgsList)
+        command << '-cp'
+        command << classpath
+        command << 'edu.umd.cs.findbugs.FindBugs2'
+        command.addAll(spotbugsArgs)
 
-                pluginArtifacts.each() { Artifact pluginArtifact ->
-                    if (log.isDebugEnabled()) {
-                        log.debug("  Adding to pluginArtifact -> ${pluginArtifact.file}")
-                    }
+        List<String> sanitizedCommand = command.collect(Object::toString)
 
-                    pathelement(location: pluginArtifact.file)
-                }
-            }
+        if (log.isDebugEnabled()) {
+            log.debug("SpotBugs command: ${sanitizedCommand}")
+        }
 
-            spotbugsArgs.each { String spotbugsArg ->
-                if (log.isDebugEnabled()) {
-                    log.debug("Spotbugs arg is ${spotbugsArg}")
-                }
-                arg(value: spotbugsArg)
-            }
+        ProcessBuilder pb = new ProcessBuilder(sanitizedCommand)
+        pb.redirectErrorStream(true)
+        // Redirect the sub-process output straight to Maven's console logs dynamically
+        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        pb.directory(new File(session.getCurrentProject().getBuild().directory))
 
-            systemPropertyVariables.each { Map.Entry<String, String> sysProp ->
-                if (log.isDebugEnabled()) {
-                    log.debug("System property ${sysProp.key} is ${sysProp.value}")
-                }
-                sysproperty(key: sysProp.key, value: sysProp.value)
+        Process process = pb.start()
+
+        long waitTime = (timeout > 0) ? (long) timeout : Long.MAX_VALUE
+        boolean finished = process.waitFor(waitTime, TimeUnit.MILLISECONDS)
+
+        if (!finished) {
+            process.destroyForcibly()
+            log.error('Timeout: killed the sub-process')
+            throw new MojoExecutionException("SpotBugs execution timed out.")
+        }
+
+        int exitCode = process.exitValue()
+
+        if (exitCode != 0) {
+            log.error("SpotBugs execution failed with exit code ${exitCode}")
+            if (failOnError) {
+                throw new MojoExecutionException("SpotBugs failed with exit code ${exitCode}")
             }
         }
 


### PR DESCRIPTION
## Replace Ant-based SpotBugs execution with ProcessBuilder

This change replaces the previous Ant task based execution path with direct `ProcessBuilder` invocation of the SpotBugs engine.

fixes #629
fixes #935

### Changes

* SpotBugs is now launched directly as a separate Java process instead of through Ant.
* The plugin now builds and manages the SpotBugs JVM invocation directly, including:
  * Java executable selection (including configured Maven JDK toolchains)
  * JVM arguments and system properties
  * SpotBugs classpath construction
  * Heap size configuration
* Existing timeout handling is now applied directly to the SpotBugs process and will terminate a hung analysis.
* Process output is forwarded directly to Maven logging, improving visibility in CI environments.
* Debug logging now includes the complete SpotBugs command line to make troubleshooting failed executions easier when Maven debug logging is enabled.
* Process exit codes are now handled explicitly:
  * SpotBugs execution failures are always reported as errors.
  * The existing `failOnError` setting controls whether those failures fail the Maven build.

### Notes

This change is intended to preserve existing plugin behavior while removing the Ant execution dependency. The `fork` option is now deprecated because SpotBugs execution is always performed in a separate process.

Users should not need to change existing configurations. Existing options such as `maxHeap`, `timeout`, `jvmArgs`, `systemPropertyVariables`, toolchain configuration, and `failOnError` continue to apply.
