### PR TITLE
Update deprecated artifact handling

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsGui.groovy
@@ -11,17 +11,19 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+
 import javax.inject.Inject
 
-import org.apache.maven.artifact.Artifact
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.plugins.annotations.ResolutionScope
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.toolchain.Toolchain
 import org.apache.maven.toolchain.ToolchainManager
 import org.codehaus.plexus.resource.ResourceManager
+import org.eclipse.aether.RepositorySystem
 
 /**
  * Launch the Spotbugs GUI.
@@ -69,11 +71,7 @@ class SpotBugsGui extends AbstractMojo implements SpotBugsPluginsTrait {
 
     /** Artifact resolver, needed to download the plugin jars. */
     @Inject
-    org.eclipse.aether.RepositorySystem repositorySystem
-
-    /** Used to look up Artifacts in the remote repository. */
-    @Inject
-    org.apache.maven.repository.RepositorySystem factory
+    RepositorySystem repositorySystem
 
     /** Toolchain manager used to retrieve the JDK toolchain. */
     @Inject

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -24,19 +24,21 @@ import java.util.jar.JarFile
 import java.util.stream.Collectors
 
 import javax.inject.Inject
-import org.apache.maven.artifact.Artifact
+
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.ReportPlugin
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.plugins.annotations.ResolutionScope
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.reporting.AbstractMavenReport
 import org.apache.maven.reporting.MavenReport
 import org.apache.maven.toolchain.Toolchain
 import org.apache.maven.toolchain.ToolchainManager
 import org.codehaus.plexus.resource.ResourceManager
 import org.codehaus.plexus.resource.loader.FileResourceLoader
+import org.eclipse.aether.RepositorySystem
 
 /**
  * Generates a SpotBugs Report when the site plugin is run.
@@ -182,11 +184,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
     /** Artifact resolver, needed to download the plugin jars. */
     @Inject
-    org.eclipse.aether.RepositorySystem repositorySystem
-
-    /** Used to look up Artifacts in the remote repository. */
-    @Inject
-    org.apache.maven.repository.RepositorySystem factory
+    RepositorySystem repositorySystem
 
     /** Toolchain manager used to retrieve the JDK toolchain. */
     @Inject

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
@@ -14,12 +14,13 @@ import groovy.xml.slurpersupport.GPathResult
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
-import org.apache.maven.RepositoryUtils
-import org.apache.maven.artifact.Artifact
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.plugin.logging.Log
 import org.apache.maven.plugin.MojoExecutionException
 import org.codehaus.plexus.resource.ResourceManager
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.resolution.ArtifactRequest
 import org.eclipse.aether.resolution.ArtifactResult
 import org.xml.sax.SAXException
@@ -32,8 +33,7 @@ trait SpotBugsPluginsTrait {
 
     // the trait needs certain objects to work, this need is expressed as abstract getters
     // classes implement them with implicitly generated property getters
-    abstract org.eclipse.aether.RepositorySystem getRepositorySystem()
-    abstract org.apache.maven.repository.RepositorySystem getFactory()
+    abstract RepositorySystem getRepositorySystem()
     abstract File getSpotbugsXmlOutputDirectory()
     abstract Log getLog()
     abstract ResourceManager getResourceManager()
@@ -44,7 +44,7 @@ trait SpotBugsPluginsTrait {
     // when fixed, should move pluginList and plugins properties here
     abstract String getPluginList()
     abstract List<PluginArtifact> getPlugins()
-    abstract List<Artifact> getPluginArtifacts()
+    abstract List<org.apache.maven.artifact.Artifact> getPluginArtifacts()
     abstract String getEffort()
     abstract MavenSession getSession()
 
@@ -91,20 +91,30 @@ trait SpotBugsPluginsTrait {
                     log.debug("  Processing Plugin: ${plugin}")
                 }
 
-                Artifact pomArtifact = plugin.classifier == null ?
-                    this.factory.createArtifact(plugin.groupId, plugin.artifactId, plugin.version, "", plugin.type) :
-                    this.factory.createArtifactWithClassifier(plugin.groupId, plugin.artifactId, plugin.version, plugin.type, plugin.classifier)
+                Artifact pomArtifact = new DefaultArtifact(
+                    plugin.groupId,
+                    plugin.artifactId,
+                    plugin.classifier,
+                    plugin.type,
+                    plugin.version
+                )
 
                 if (log.isDebugEnabled()) {
                     log.debug("  Added Artifact: ${pomArtifact}")
                 }
 
-                ArtifactRequest request = new ArtifactRequest(RepositoryUtils.toArtifact(pomArtifact), session.getCurrentProject().getRemoteProjectRepositories(), null)
-                ArtifactResult result = this.repositorySystem.resolveArtifact(session.getRepositorySession(), request)
+                ArtifactRequest request = new ArtifactRequest(
+                    pomArtifact,
+                    session.getCurrentProject().getRemoteProjectRepositories(),
+                    null
+                )
 
-                pomArtifact.setFile(result.getArtifact().getFile())
+                ArtifactResult result = this.repositorySystem.resolveArtifact(
+                    session.getRepositorySession(),
+                    request
+                )
 
-                urlPlugins << resourceHelper.getResourceFile(pomArtifact.file.absolutePath).absolutePath
+                urlPlugins << resourceHelper.getResourceFile(result.artifact.file.absolutePath).absolutePath
             }
         }
 
@@ -120,7 +130,7 @@ trait SpotBugsPluginsTrait {
             // (e.g. when a plugin is declared both via <plugins> config and as a <dependency>).
             Set<String> addedFileNames = urlPlugins.collect { new File(it).name } as Set
 
-            pluginArtifacts.each { Artifact artifact ->
+            pluginArtifacts.each { org.apache.maven.artifact.Artifact artifact ->
                 if ('com.github.spotbugs' != artifact.groupId && artifact.file != null && isSpotBugsPlugin(artifact.file)) {
                     String jarFileName = artifact.file.name
                     if (!addedFileNames.contains(jarFileName)) {
@@ -209,7 +219,7 @@ trait SpotBugsPluginsTrait {
         }
 
         if (pluginArtifacts) {
-            pluginArtifacts.each { Artifact artifact ->
+            pluginArtifacts.each { org.apache.maven.artifact.Artifact artifact ->
                 if ('com.github.spotbugs' != artifact.groupId && artifact.file != null && artifact.file.exists() && artifact.file.name.endsWith('.jar')) {
                     pluginJars << artifact.file
                 }

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTrait.groovy
@@ -122,9 +122,7 @@ trait SpotBugsPluginsTrait {
         // Any artifact on the plugin classpath (pluginArtifacts) that contains findbugs.xml
         // and is not part of the SpotBugs core (com.github.spotbugs group) is treated as a plugin extension.
         if (pluginArtifacts) {
-            if (log.isDebugEnabled()) {
-                log.debug('  Scanning plugin artifacts for SpotBugs extension plugins (added via <dependencies>)')
-            }
+            log.debug('  Scanning plugin artifacts for SpotBugs extension plugins (added via <dependencies>)')
 
             // Collect file names already in the plugin list to avoid adding the same JAR twice
             // (e.g. when a plugin is declared both via <plugins> config and as a <dependency>).

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
@@ -1109,6 +1109,181 @@ class SpotBugsMojoTest extends Specification {
     }
 
     // -------------------------------------------------------------------------
+    // executeSpotbugs() – forks and runs the real SpotBugs engine
+    // -------------------------------------------------------------------------
+    //
+    // These tests invoke the private executeSpotbugs(File) via reflection. Some tests
+    // use the real test classpath (SpotBugs core is a compile dependency of this module)
+    // to exercise a genuine successful analysis/toolchain/timeout run, while others use an
+    // empty classpath to deterministically and quickly trigger the failure / noClassOk /
+    // debug-retention branches without depending on a real SpotBugs execution succeeding.
+
+    void 'executeSpotbugs runs a real SpotBugs analysis and writes xml output with bug count'() {
+        given:
+        File classesDir = compileBuggyClass(tempDir)
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, realClasspathArtifacts())
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        outputFile.exists()
+        outputFile.text.contains('BugInstance')
+        mojo.bugCount >= 1
+        mojo.errorCount == 0
+    }
+
+    void 'executeSpotbugs writes html and sarif temp output when both are enabled'() {
+        given:
+        File classesDir = compileBuggyClass(tempDir)
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, realClasspathArtifacts())
+        mojo.htmlOutput = true
+        mojo.sarifOutput = true
+        mojo.sarifOutputDirectory = tempDir
+        mojo.sarifOutputFilename = 'spotbugsSarif.json'
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        outputFile.exists()
+        new File(tempDir, 'spotbugsSarif.json').exists()
+    }
+
+    void 'executeSpotbugs uses toolchain-provided java executable when available'() {
+        given:
+        File classesDir = compileBuggyClass(tempDir)
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, realClasspathArtifacts())
+        String javaBin = new File(System.getProperty('java.home'), 'bin/java').absolutePath
+        org.apache.maven.toolchain.Toolchain toolchain = Mock(org.apache.maven.toolchain.Toolchain) {
+            findTool('java') >> javaBin
+        }
+        mojo.toolchainManager = Mock(org.apache.maven.toolchain.ToolchainManager) {
+            getToolchainFromBuildContext('jdk', _) >> toolchain
+        }
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        outputFile.exists()
+        mojo.bugCount >= 1
+    }
+
+    void 'executeSpotbugs includes custom jvmArgs and systemPropertyVariables without error'() {
+        given:
+        File classesDir = compileBuggyClass(tempDir)
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, realClasspathArtifacts())
+        mojo.jvmArgs = '-Dcustom.arg=true'
+        mojo.systemPropertyVariables = ['my.sys.prop': 'value']
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        outputFile.exists()
+    }
+
+    void 'executeSpotbugs throws MojoExecutionException on timeout'() {
+        given:
+        File classesDir = compileBuggyClass(tempDir)
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, realClasspathArtifacts())
+        mojo.timeout = 1
+
+        when:
+        invokeExecuteSpotbugs(mojo, new File(tempDir, 'spotbugsXml.xml'))
+
+        then:
+        org.apache.maven.plugin.MojoExecutionException ex = thrown(org.apache.maven.plugin.MojoExecutionException)
+        ex.message.contains('timed out')
+    }
+
+    void 'executeSpotbugs throws MojoExecutionException when SpotBugs process fails and failOnError is true'() {
+        given:
+        File classesDir = new File(tempDir, 'classes-broken-1')
+        classesDir.mkdirs()
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, [])
+        mojo.failOnError = true
+
+        when:
+        invokeExecuteSpotbugs(mojo, new File(tempDir, 'spotbugsXml.xml'))
+
+        then:
+        thrown(org.apache.maven.plugin.MojoExecutionException)
+    }
+
+    void 'executeSpotbugs does not throw when SpotBugs process fails and failOnError is false'() {
+        given:
+        File classesDir = new File(tempDir, 'classes-broken-2')
+        classesDir.mkdirs()
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, [])
+        mojo.failOnError = false
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        noExceptionThrown()
+        // xmlTempFile ends up empty (process never ran SpotBugs), and noClassOk=false,
+        // so the final xml output file is never written.
+        !outputFile.exists()
+    }
+
+    void 'executeSpotbugs writes minimal BugCollection xml when noClassOk=true and analysis produced no output'() {
+        given:
+        File classesDir = new File(tempDir, 'classes-broken-3')
+        classesDir.mkdirs()
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, [])
+        mojo.failOnError = false
+        mojo.noClassOk = true
+        File outputFile = new File(tempDir, 'spotbugsXml.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, outputFile)
+
+        then:
+        outputFile.exists()
+        outputFile.text.contains('<BugCollection')
+    }
+
+    void 'executeSpotbugs keeps xml temp file when debug is true'() {
+        given:
+        File classesDir = new File(tempDir, 'classes-broken-4')
+        classesDir.mkdirs()
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, [])
+        mojo.failOnError = false
+        mojo.debug = true
+        File xmlTempFile = new File(tempDir, 'spotbugsTemp.xml')
+
+        when:
+        invokeExecuteSpotbugs(mojo, new File(tempDir, 'spotbugsXml.xml'))
+
+        then:
+        xmlTempFile.exists()
+    }
+
+    void 'executeSpotbugs does not create html or sarif temp files when both outputs disabled'() {
+        given:
+        File classesDir = new File(tempDir, 'classes-broken-5')
+        classesDir.mkdirs()
+        SpotBugsMojo mojo = buildExecuteSpotbugsMojo(tempDir, classesDir, [])
+        mojo.failOnError = false
+        mojo.htmlOutput = false
+        mojo.sarifOutput = false
+
+        when:
+        invokeExecuteSpotbugs(mojo, new File(tempDir, 'spotbugsXml.xml'))
+
+        then:
+        !new File(tempDir, 'spotbugs.html').exists()
+    }
+
+    // -------------------------------------------------------------------------
     // Helper methods
     // -------------------------------------------------------------------------
 
@@ -1168,6 +1343,117 @@ class SpotBugsMojoTest extends Specification {
             }
         }
         throw new NoSuchFieldException("Field '${fieldName}' not found in ${target.getClass().name} hierarchy")
+    }
+
+    /**
+     * Builds a SpotBugsMojo wired with minimal mocks sufficient to invoke the private
+     * executeSpotbugs(File) method end-to-end (real ProcessBuilder fork).
+     */
+    private SpotBugsMojo buildExecuteSpotbugsMojo(File baseDir, File classesDir, List<Artifact> pluginArtifactsList) {
+        org.apache.maven.model.Build build = Mock(org.apache.maven.model.Build) {
+            getDirectory() >> baseDir.absolutePath
+        }
+        MavenProject project = Mock(MavenProject) {
+            getName() >> 'test-project'
+            getCompileSourceRoots() >> []
+            getTestCompileSourceRoots() >> []
+            getCompileClasspathElements() >> []
+            getTestClasspathElements() >> []
+            getBuild() >> build
+            getFile() >> new File(baseDir, 'pom.xml')
+            getRemoteProjectRepositories() >> []
+        }
+        MavenSession session = Mock(MavenSession) {
+            getCurrentProject() >> project
+        }
+
+        SpotBugsMojo mojo = new SpotBugsMojo()
+        mojo.log = Mock(Log) { isDebugEnabled() >> false }
+        mojo.session = session
+        mojo.resourceManager = Mock(org.codehaus.plexus.resource.ResourceManager)
+        mojo.pluginArtifacts = pluginArtifactsList
+        mojo.classFilesDirectory = classesDir
+        mojo.testClassFilesDirectory = new File(baseDir, 'nonexistent-test-classes')
+        mojo.includeTests = false
+        mojo.outputDirectory = baseDir
+        mojo.spotbugsXmlOutputDirectory = baseDir
+        mojo.effort = 'Default'
+        mojo.threshold = 'Default'
+        mojo.outputEncoding = 'UTF-8'
+        mojo.systemPropertyVariables = [:]
+        mojo.maxHeap = 256
+        mojo.timeout = 0
+        mojo.failOnError = true
+        setField(mojo, 'project', project)
+
+        return mojo
+    }
+
+    /**
+     * Builds an Artifact list mirroring the real test JVM's classpath, so the forked
+     * SpotBugs process can actually locate and run edu.umd.cs.findbugs.FindBugs2
+     * (SpotBugs core is a compile dependency of this module, so it is already present).
+     */
+    private List<Artifact> realClasspathArtifacts() {
+        String cp = System.getProperty('java.class.path')
+        return cp.split(File.pathSeparator).findAll { String path -> new File(path).exists() }.collect { String path ->
+            return Mock(Artifact) {
+                getFile() >> new File(path)
+                // Avoid the extension-plugin auto-detection loop opening every real jar on the classpath.
+                getGroupId() >> 'com.github.spotbugs'
+            }
+        }
+    }
+
+    /**
+     * Compiles a tiny Java class containing a guaranteed, default-severity SpotBugs
+     * finding (DLS_DEAD_LOCAL_STORE) into a fresh classes directory under baseDir.
+     */
+    private static File compileBuggyClass(File baseDir) {
+        File srcDir = new File(baseDir, 'src')
+        srcDir.mkdirs()
+        File srcFile = new File(srcDir, 'Buggy.java')
+        srcFile.text = '''
+            public class Buggy {
+                public void bug() {
+                    String s = null;
+                    s.length();
+                }
+            }
+        '''.stripIndent()
+
+        File classesDir = new File(baseDir, 'classes')
+        classesDir.mkdirs()
+
+        javax.tools.JavaCompiler compiler = javax.tools.ToolProvider.getSystemJavaCompiler()
+        javax.tools.StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)
+        try {
+            Iterable<? extends javax.tools.JavaFileObject> units = fileManager.getJavaFileObjectsFromFiles([srcFile])
+            List<String> options = ['-d', classesDir.absolutePath]
+            boolean success = compiler.getTask(null, fileManager, null, options, null, units).call()
+            if (!success) {
+                throw new IllegalStateException('Failed to compile Buggy.java test fixture')
+            }
+        } finally {
+            fileManager.close()
+        }
+
+        return classesDir
+    }
+
+    /**
+     * Invokes the private executeSpotbugs(File) method via reflection, unwrapping and
+     * rethrowing the original (possibly checked) exception rather than the reflection
+     * InvocationTargetException wrapper, so Spock's thrown() works naturally.
+     */
+    private static void invokeExecuteSpotbugs(SpotBugsMojo mojo, File outputFile) {
+        Method method = SpotBugsMojo.class.getDeclaredMethod('executeSpotbugs', File)
+        method.setAccessible(true)
+        try {
+            method.invoke(mojo, outputFile)
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw e.cause
+        }
     }
 
 }

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
@@ -11,6 +11,7 @@ import java.lang.reflect.Method
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.execution.MavenExecutionRequest
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Model
@@ -21,6 +22,7 @@ import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugin.MojoExecution
 import org.apache.maven.plugin.logging.Log
 import org.apache.maven.project.MavenProject
+
 import spock.lang.Specification
 import spock.lang.TempDir
 

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTraitTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsPluginsTraitTest.groovy
@@ -6,16 +6,18 @@
  */
 package org.codehaus.mojo.spotbugs
 
-import spock.lang.Specification
-import org.apache.maven.artifact.Artifact
-import org.apache.maven.plugin.logging.Log
-import org.apache.maven.execution.MavenSession
-import org.codehaus.plexus.resource.ResourceManager
-
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
+
+import org.apache.maven.artifact.Artifact
+import org.apache.maven.execution.MavenSession
+import org.apache.maven.plugin.logging.Log
+import org.codehaus.plexus.resource.ResourceManager
+import org.eclipse.aether.RepositorySystem
+
+import spock.lang.Specification
 
 class SpotBugsPluginsTraitTest extends Specification {
 
@@ -23,15 +25,13 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         ResourceManager resourceManager = Mock()
-        org.eclipse.aether.RepositorySystem repositorySystem = Mock()
-        org.apache.maven.repository.RepositorySystem factory = Mock()
+        RepositorySystem repositorySystem = Mock()
         MavenSession session = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl(
             effort,
             log,
             resourceManager,
             repositorySystem,
-            factory,
             session
         )
 
@@ -49,7 +49,7 @@ class SpotBugsPluginsTraitTest extends Specification {
     void "isSpotBugsPlugin returns true for JAR containing findbugs.xml at root"() {
         given:
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", Mock(Log), Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         Path jarPath = Files.createTempFile("test-plugin", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
             jos.putNextEntry(new JarEntry("findbugs.xml"))
@@ -67,7 +67,7 @@ class SpotBugsPluginsTraitTest extends Specification {
     void "isSpotBugsPlugin returns false for JAR without findbugs.xml"() {
         given:
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", Mock(Log), Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         Path jarPath = Files.createTempFile("not-a-plugin", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
             jos.putNextEntry(new JarEntry("com/example/Foo.class"))
@@ -85,7 +85,7 @@ class SpotBugsPluginsTraitTest extends Specification {
     void "isSpotBugsPlugin returns false for null file"() {
         given:
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", Mock(Log), Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         expect:
         impl.isSpotBugsPlugin(null) == false
@@ -94,7 +94,7 @@ class SpotBugsPluginsTraitTest extends Specification {
     void "isSpotBugsPlugin returns false for non-JAR file"() {
         given:
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", Mock(Log), Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         Path txtPath = Files.createTempFile("not-a-jar", ".txt")
         txtPath.toFile().text = "hello"
 
@@ -108,7 +108,7 @@ class SpotBugsPluginsTraitTest extends Specification {
     void "buildBugTypeUrlMap returns empty map when no plugins are configured"() {
         given:
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", Mock(Log), Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         expect:
         impl.buildBugTypeUrlMap(null).isEmpty()
@@ -118,7 +118,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         // Create a fake fb-contrib plugin JAR with a findbugs.xml that declares two bug patterns
         Path jarPath = Files.createTempFile("fb-contrib", ".jar")
@@ -147,7 +147,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         Path jarPath = Files.createTempFile("fb-contrib-override", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
@@ -174,7 +174,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         Path jarPath = Files.createTempFile("custom-plugin", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
@@ -201,7 +201,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         Path jarPath = Files.createTempFile("unknown-plugin", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
@@ -227,7 +227,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         Path jarPath = Files.createTempFile("artifact-plugin", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
@@ -257,7 +257,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         Path jarPath = Files.createTempFile("spotbugs-core", ".jar")
         new JarOutputStream(Files.newOutputStream(jarPath)).withCloseable { jos ->
@@ -294,7 +294,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         }
         Path tempOutputDir = Files.createTempDirectory("spotbugs-output")
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
 
         when:
@@ -321,7 +321,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         }
 
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
         impl.pluginList = jarPath.toAbsolutePath().toString()
 
@@ -354,7 +354,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         artifact.file >> jarPath.toFile()
 
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
         impl.pluginArtifacts = [artifact]
 
@@ -387,7 +387,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         artifact.file >> jarPath.toFile()
 
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
         impl.pluginArtifacts = [artifact]
 
@@ -420,7 +420,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         artifact.file >> jarPath.toFile()
 
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
         impl.pluginArtifacts = [artifact]
 
@@ -439,7 +439,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         // Simulate an XML exclude filter file passed as a plugin artifact (not a JAR)
         Path xmlFile = Files.createTempFile("exclude-filter", ".xml")
@@ -465,7 +465,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         given:
         Log log = Mock()
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
 
         // Create a file that looks like a JAR but is not a valid ZIP/JAR
         Path corruptJar = Files.createTempFile("corrupt-plugin", ".jar")
@@ -497,7 +497,7 @@ class SpotBugsPluginsTraitTest extends Specification {
         }
 
         SpotBugsPluginsTraitImpl impl = new SpotBugsPluginsTraitImpl("default", log, Mock(ResourceManager),
-            Mock(org.eclipse.aether.RepositorySystem), Mock(org.apache.maven.repository.RepositorySystem), Mock(MavenSession))
+            Mock(RepositorySystem), Mock(MavenSession))
         impl.spotbugsXmlOutputDirectory = tempOutputDir.toFile()
         impl.pluginList = jarPath.toAbsolutePath().toString()
 
@@ -521,23 +521,20 @@ class SpotBugsPluginsTraitTest extends Specification {
         Log log
         File spotbugsXmlOutputDirectory = new File(".")
         ResourceManager resourceManager
-        org.eclipse.aether.RepositorySystem repositorySystem
-        org.apache.maven.repository.RepositorySystem factory
+        RepositorySystem repositorySystem
         MavenSession session
 
         SpotBugsPluginsTraitImpl(
             String effort,
             Log log,
             ResourceManager resourceManager,
-            org.eclipse.aether.RepositorySystem repositorySystem,
-            org.apache.maven.repository.RepositorySystem factory,
+            RepositorySystem repositorySystem,
             MavenSession session
         ) {
             this.effort = effort
             this.log = log
             this.resourceManager = resourceManager
             this.repositorySystem = repositorySystem
-            this.factory = factory
             this.session = session
         }
     }


### PR DESCRIPTION
- improve tests
- cleanup unnecessary wrapper around debug log that just prints pure java string