### PR TITLE
Require maven 3.8.9 or better

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Maven Mojo Plug-In to generate reports based on the [SpotBugs](https://github.co
 ## Running spotbugs-maven-plugin Requirements ##
 
 * Java 11 or better is required for spotbugs analysis.
-* Maven 3.6.3 or better is required for spotbugs analysis.
+* Maven 3.8.9 or better is required for spotbugs analysis.
 
 ## Usage ##
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     </contributors>
 
     <prerequisites>
-        <maven>3.6.3</maven>
+        <maven>3.8.9</maven>
     </prerequisites>
 
     <scm>


### PR DESCRIPTION
- maven support for 3.8.x line ended 1 year and 2 months ago (14 Jun 2025).
- maven support for 3.6.x line ended 5 years ago (30 Mar 2021).
- At this point further modernization has been done that could lead to incompatibilities.
- All testing is done at 3.8.9 or better.

Therefore the floor is moved to 3.8.9 with understanding that Maven 3.8.x itself is no longer by Maven.  Users are generally expected to be on maven 3.9.x or current release candidates of maven 4.0.