### PR TITLE
Fixes 1511, removed shaded 'outputEncoding' that maven reporting added in 2014

### DIFF
--- a/src/it/check-no-missing-classes/pom.xml
+++ b/src/it/check-no-missing-classes/pom.xml
@@ -34,7 +34,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- These two are used due to old compiler on maven 3.6.3 GHA build -->
+    <!-- These two are used due to old compiler default on maven 3.8.9 GHA build -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 

--- a/src/it/common.xml
+++ b/src/it/common.xml
@@ -19,6 +19,12 @@
 
   <url>https://spotbugs.github.io/spotbugs-maven-plugin/</url>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
@@ -43,12 +49,6 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
 
   <build>
     <sourceDirectory>@project.build.directory@/spotbugs-@spotbugs-scm.version@/spotbugsTestCases/src/java</sourceDirectory>

--- a/src/it/empty/pom.xml
+++ b/src/it/empty/pom.xml
@@ -33,6 +33,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <!-- These two are used due to old compiler default on maven 3.8.9 GHA build -->
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <build>

--- a/src/it/encoding-default/invoker.properties
+++ b/src/it/encoding-default/invoker.properties
@@ -1,0 +1,11 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file for details.
+#
+# Copyright 2005-2026 the original author or authors.
+#
+
+invoker.goals = clean install site --no-transfer-progress
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/encoding-default/pom.xml
+++ b/src/it/encoding-default/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
+
+    Copyright 2005-2026 the original author or authors.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Parent is disabled on purpose
+  <parent>
+    <groupId>spotbugs-maven-plugin.it</groupId>
+    <artifactId>common</artifactId>
+    <version>1.0</version>
+    <relativePath>../common.xml</relativePath>
+  </parent>
+  -->
+
+  <groupId>spotbugs-maven-plugin.it</groupId>
+  <artifactId>encoding-default</artifactId>
+  <version>1.0</version>
+
+  <name>encoding-default</name>
+
+  <url>https://spotbugs.github.io/spotbugs-maven-plugin/</url>
+
+  <properties>
+    <!-- Do not set encoding to force default encoding behaviour -->
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <version>@spotbugs.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>@junitVersion@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>@slf4jVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>@servletApiVersion@</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.directory@/spotbugs-@spotbugs-scm.version@/spotbugsTestCases/src/java</sourceDirectory>
+    <testSourceDirectory>@project.basedir@/src/it-src/test/java</testSourceDirectory>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>@clean.plugin@</version>
+        <configuration>
+          <force>true</force>
+        </configuration>
+      </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <configuration>
+            <failOnError>false</failOnError>
+          </configuration>
+          <!-- Keep 'check' here so the integration test exercises AbstractMavenReport's encoding logic. -->
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+          </execution>
+        </executions>
+        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>@site.plugin@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>@project-info.plugin@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>@jxr.plugin@</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <profiles>
+    <profile>
+      <!-- Override parameters not valid in maven-clean-plugin 4.x -->
+      <id>maven4</id>
+      <activation>
+        <property>
+          <name>maven.version</name>
+          <value>4.0.0-rc-6</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <!-- force parameter is not yet available in maven-clean-plugin 4.x -->
+            <configuration combine.self="override"/>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/src/it/encoding-default/pom.xml
+++ b/src/it/encoding-default/pom.xml
@@ -31,6 +31,12 @@
 
   <properties>
     <!-- Do not set encoding to force default encoding behaviour -->
+
+    <!-- These two are used due to old compiler default on maven 3.8.9 GHA build -->
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/src/it/encoding-default/src/site/site.xml
+++ b/src/it/encoding-default/src/site/site.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
+
+    Copyright 2005-2026 the original author or authors.
+
+-->
+<site name="${project.name}" xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+
+  <bannerLeft name="SpotBugs Maven Plugin" />
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>2.1.0</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>false</topBarEnabled>
+      <sideBarEnabled>false</sideBarEnabled>
+      <breadcrumbDivider>»</breadcrumbDivider>
+      <gitHub>
+        <projectId>spotbugs/spotbugs-maven-plugin</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>red</ribbonColor>
+      </gitHub>
+      <ohloh>
+        <projectId>spotbugs-maven-plugin</projectId>
+        <widget>thin-badge</widget>
+      </ohloh>
+    </fluidoSkin>
+  </custom>
+
+  <publishDate format="yyyy-MM-dd" position="right"/>
+  <version position="right"/>
+
+</site>

--- a/src/it/encoding-default/verify.groovy
+++ b/src/it/encoding-default/verify.groovy
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
+ *
+ * Copyright 2005-2026 the original author or authors.
+ */
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import groovy.xml.slurpersupport.NodeChild
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+Path spotbugsHtml =  basedir.toPath().resolve('target/site/spotbugs.html')
+assert Files.exists(spotbugsHtml)
+
+Path spotbugXdoc = basedir.toPath().resolve('target/spotbugs.xml')
+assert Files.exists(spotbugXdoc)
+
+Path spotbugXml = basedir.toPath().resolve('target/spotbugsXml.xml')
+assert Files.exists(spotbugXml)
+
+println '******************'
+println 'Checking HTML file'
+println '******************'
+
+XmlSlurper xmlSlurper = new XmlSlurper()
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+
+// Temporarily allow DOCTYPE for HTML parsing
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+GPathResult path = xmlSlurper.parse(spotbugsHtml)
+xmlSlurper.setFeature('http://apache.org/xml/features/disallow-doctype-decl', true)
+
+int spotbugsErrors = path.body.'**'.find { NodeChild main -> main.@id == 'bodyColumn' }.section[1].table.tr[1].td[1].toInteger()
+println "Error Count is ${spotbugsErrors}"
+
+println '*********************************'
+println 'Checking Spotbugs Native XML file'
+println '*********************************'
+
+path = xmlSlurper.parse(spotbugXml)
+
+List<NodeChild> allNodes = path.depthFirst().toList()
+int spotbugsXmlErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
+println "BugInstance size is ${spotbugsXmlErrors}"
+
+assert spotbugsErrors == spotbugsXmlErrors
+
+println '******************'
+println 'Checking xDoc file'
+println '******************'
+
+path = xmlSlurper.parse(spotbugXdoc)
+
+allNodes = path.depthFirst().toList()
+int xdocErrors = allNodes.count { NodeChild node -> node.name() == 'BugInstance' }
+println "BugInstance size is ${xdocErrors}"
+
+assert xdocErrors == spotbugsXmlErrors

--- a/src/it/noClassOk/pom.xml
+++ b/src/it/noClassOk/pom.xml
@@ -34,7 +34,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- These two are used due to old compiler on maven 3.6.3 GHA build -->
+    <!-- These two are used due to old compiler default on maven 3.8.9 GHA build -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 

--- a/src/it/skipEmpty/pom.xml
+++ b/src/it/skipEmpty/pom.xml
@@ -33,7 +33,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- These two are used due to old compiler on maven 3.6.3 GHA build -->
+    <!-- These two are used due to old compiler default on maven 3.8.9 GHA build -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojo.groovy
@@ -40,15 +40,6 @@ class SpotBugsAggregateMojo extends AbstractMavenReport {
     @Parameter(defaultValue = '${project.reporting.outputDirectory}', required = true)
     File outputDirectory
 
-    /**
-     * The file encoding to use when creating the HTML reports. If the property
-     * <code>project.reporting.outputEncoding</code> is not set, utf-8 is used.
-     *
-     * @since 4.9.4.2
-     */
-    @Parameter(defaultValue = '${project.reporting.outputEncoding}', property = 'outputEncoding')
-    String outputEncoding
-
     /** Threshold of minimum bug severity to report. Valid values are High, Default, Low, Ignore, and Exp (for experimental). */
     @Parameter(defaultValue = 'Default', property = 'spotbugs.threshold')
     String threshold

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -169,15 +169,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
     @Parameter (defaultValue = '${session}', readonly = true, required = true)
     MavenSession session
 
-    /**
-     * The file encoding to use when creating the HTML reports. If the property <code>project.reporting.outputEncoding</code>
-     * is not set, utf-8 is used.
-     *
-     * @since 2.2
-     */
-    @Parameter(defaultValue = '${project.reporting.outputEncoding}', property = 'outputEncoding')
-    String outputEncoding
-
     /** Threshold of minimum bug severity to report. Valid values are High, Default, Low, Ignore, and Exp (for experimental). */
     @Parameter(defaultValue = 'Default', property = 'spotbugs.threshold')
     String threshold

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojoTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojoTest.groovy
@@ -371,7 +371,6 @@ class SpotBugsAggregateMojoTest extends Specification {
         mojo.spotbugsXmlOutputFilename = 'spotbugsXml.xml'
         mojo.threshold = 'High'
         mojo.effort = 'Max'
-        mojo.outputEncoding = 'UTF-8'
 
         then:
         mojo.skip

--- a/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
+++ b/src/test/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojoTest.groovy
@@ -1409,7 +1409,6 @@ class SpotBugsMojoTest extends Specification {
         mojo.spotbugsXmlOutputDirectory = baseDir
         mojo.effort = 'Default'
         mojo.threshold = 'Default'
-        mojo.outputEncoding = 'UTF-8'
         mojo.systemPropertyVariables = [:]
         mojo.maxHeap = 256
         mojo.timeout = 0


### PR DESCRIPTION
Fixes #1511 

## Breaking configuration changes:

The SpotBugs Maven Plugin also no longer overrides Maven Reporting's ```outputEncoding``` parameter. Maven Reporting treats ```outputEncoding``` as read-only and obtains its value from the ```project.reporting.outputEncoding``` project property. Users who previously configured ```outputEncoding``` directly on the SpotBugs Maven Plugin must configure ```project.reporting.outputEncoding``` instead.

When value is not set, maven reporting will default to utf-8 as does this plugin.