### PR TITLE
Use super class outputDirectory removing all duplication

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsAggregateMojo.groovy
@@ -36,10 +36,6 @@ import org.apache.maven.reporting.MavenReport
         requiresProject = true, threadSafe = true)
 class SpotBugsAggregateMojo extends AbstractMavenReport {
 
-    /** Location where the generated HTML aggregate report will be created. */
-    @Parameter(defaultValue = '${project.reporting.outputDirectory}', required = true)
-    File outputDirectory
-
     /** Threshold of minimum bug severity to report. Valid values are High, Default, Low, Ignore, and Exp (for experimental). */
     @Parameter(defaultValue = 'Default', property = 'spotbugs.threshold')
     String threshold
@@ -176,7 +172,7 @@ class SpotBugsAggregateMojo extends AbstractMavenReport {
             return
         }
 
-        if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+        if (!super.outputDirectory.exists() && !super.outputDirectory.mkdirs()) {
             throw new MojoExecutionException('Cannot create html output directory')
         }
 
@@ -218,7 +214,7 @@ class SpotBugsAggregateMojo extends AbstractMavenReport {
         generator.setThreshold(threshold)
         generator.setEffort(effort)
         generator.setSpotbugsResults(aggregatedResults)
-        generator.setOutputDirectory(outputDirectory)
+        generator.setOutputDirectory(super.outputDirectory)
         generator.generateReport()
 
         if (log.isDebugEnabled()) {
@@ -342,28 +338,6 @@ class SpotBugsAggregateMojo extends AbstractMavenReport {
         writer.close()
 
         return aggregatedXmlFile
-    }
-
-    /**
-     * Returns the report output directory.
-     *
-     * @return full path to the directory where the files in the site get copied to
-     * @see AbstractMavenReport#getOutputDirectory()
-     */
-    @Override
-    protected String getOutputDirectory() {
-        return outputDirectory.absolutePath
-    }
-
-    /**
-     * Sets the report output directory.
-     *
-     * @see AbstractMavenReport#setReportOutputDirectory(File)
-     */
-    @Override
-    void setReportOutputDirectory(File reportOutputDirectory) {
-        super.setReportOutputDirectory(reportOutputDirectory)
-        this.outputDirectory = reportOutputDirectory
     }
 
     /**

--- a/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy
@@ -47,10 +47,6 @@ import org.eclipse.aether.RepositorySystem
 @Mojo(name = 'spotbugs', requiresDependencyResolution = ResolutionScope.TEST, requiresProject = true, threadSafe = true)
 class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
-    /** Location where generated html will be created allowed to be not read only as defined in AbstractMavenParent. */
-    @Parameter(defaultValue = '${project.reporting.outputDirectory}', required = true)
-    File outputDirectory
-
     /**
      * Turn on and off xml output of the Spotbugs report.
      *
@@ -686,7 +682,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
         generateXDoc(locale)
 
-        if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+        if (!super.outputDirectory.exists() && !super.outputDirectory.mkdirs()) {
             throw new MojoExecutionException('Cannot create html output directory')
         }
 
@@ -721,7 +717,7 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
                 xmlSlurper.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
 
                 generator.setSpotbugsResults(xmlSlurper.parse(outputSpotbugsFile))
-                generator.setOutputDirectory(new File(outputDirectory.getAbsolutePath()))
+                generator.setOutputDirectory(super.outputDirectory)
                 generator.generateReport()
 
                 if (log.isDebugEnabled()) {
@@ -784,19 +780,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
 
             xDocsReporter.generateReport()
         }
-    }
-
-    /**
-     * Returns the report output directory allowed to be not read only as defined in AbstractMavenParent.
-     *
-     * Called by AbstractMavenReport.execute() for creating the sink.
-     *
-     * @return full path to the directory where the files in the site get copied to
-     * @see AbstractMavenReport#getOutputDirectory()
-     */
-    @Override
-    protected String getOutputDirectory() {
-        return outputDirectory.getAbsolutePath()
     }
 
     /**
@@ -1479,17 +1462,6 @@ class SpotBugsMojo extends AbstractMavenReport implements SpotBugsPluginsTrait {
         }
 
         return thresholdParameter
-    }
-
-    /**
-     *  Set report output directory, allowed to be not read only as defined in AbstractMavenParent.
-     *
-     * @see AbstractMavenReport#setReportOutputDirectory(File)
-     */
-    @Override
-    void setReportOutputDirectory(File reportOutputDirectory) {
-        super.setReportOutputDirectory(reportOutputDirectory)
-        this.outputDirectory = reportOutputDirectory
     }
 
 }


### PR DESCRIPTION
super calls needed to cause groovy to call the property instead of the getter as getter switches to string from file.  Prior code was setting both super class and local class with javadocs noting this which now are removed.  User experience is the same.